### PR TITLE
docs: portfolio narrative skeleton — STORY/INCIDENT/INTERVIEW/BENCHMARK + ADR-001

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,48 @@
+# Benchmark — 📅 Planned
+
+> Phase 별 부하 측정 + 결과 archive. Phase 2~6 진행 시 채워짐.
+
+## Planned Layout
+
+```
+benchmark/
+├── README.md                    (이 파일)
+├── k6/                          k6 부하 스크립트
+│   ├── README.md
+│   ├── mvc-baseline.js          (Phase 2)
+│   ├── mvc-coalesced-inprocess.js
+│   ├── coalesced-redis-multi.js (Phase 3)
+│   ├── webflux-baseline.js      (Phase 6)
+│   └── webflux-coalesced.js
+├── scripts/                     자동화 shell scripts
+│   ├── README.md
+│   ├── run-mvc.sh               (Phase 2)
+│   ├── run-redis-multi.sh       (Phase 3)
+│   └── run-webflux.sh           (Phase 6)
+└── results/                     측정 결과 archive (날짜별)
+    ├── README.md
+    └── <YYYY-MM-DD>/
+        ├── mvc-baseline.md
+        ├── mvc-coalesced.md
+        └── ...
+```
+
+## Planned Workflow
+
+각 Phase 측정 시:
+
+1. `cd infra && docker-compose up -d` — 인프라 기동
+2. `bash benchmark/scripts/run-<phase>.sh` — k6 부하 + Prometheus 스냅샷
+3. 결과를 `benchmark/results/<YYYY-MM-DD>/` 에 markdown + raw csv 로 저장
+4. `docs/BENCHMARK.md` 의 Expected Results 표를 Measured 값으로 갱신
+
+## Status
+
+- [ ] Phase 2 시작 시 mvc 시리즈 작성
+- [ ] Phase 3 시작 시 redis-multi 작성
+- [ ] Phase 6 시작 시 webflux 시리즈 작성
+
+## References
+
+- [docs/BENCHMARK.md](../docs/BENCHMARK.md) — 측정 방법론 + business impact framework
+- [docs/STORY.md Act 6](../docs/STORY.md) — Result narrative (운영 추정값 + 측정 예정 명시)

--- a/benchmark/k6/README.md
+++ b/benchmark/k6/README.md
@@ -1,0 +1,32 @@
+# Benchmark — k6 Scripts (📅 Planned)
+
+> Phase 2~6 에 추가됨.
+
+## Planned Scenarios
+
+[docs/BENCHMARK.md](../../docs/BENCHMARK.md) 에 정의된 3 시나리오 각각 k6 script 로:
+
+### Scenario 1: Burst Coalescing
+한 instant 에 100 동시 요청. Pure single-flight 효과 검증 (외부 호출 1회 가설).
+
+### Scenario 2: Sustained + Cache TTL
+60s 지속 부하. Cache TTL 5분 가정. 외부 호출 ~ 1회 (TTL 동안) 가설.
+
+### Scenario 3: Pure Single-Flight (No Cache)
+60s 지속 부하 + Cache 비활성. Owner 완료 후 다음 wave 새 owner. 외부 호출 ~ 120회 가설 (60s ÷ 500ms = 120).
+
+## Planned Files
+
+- `mvc-baseline.js` — Phase 2 — coalesce 없음
+- `mvc-coalesced-inprocess.js` — Phase 2 — in-process coalesce
+- `coalesced-redis-multi.js` — Phase 3 — multi-instance Redis coalesce
+- `webflux-baseline.js` — Phase 6 — reactive baseline
+- `webflux-coalesced.js` — Phase 6 — reactive coalesce
+
+## Common Conventions
+
+- Warm-up 30s + sustained 60s + cool-down 30s
+- 100 VU
+- 동일 key (worst case for thundering herd)
+- 3회 반복, 중앙값 사용
+- 결과는 `benchmark/results/<YYYY-MM-DD>/` 에 저장

--- a/benchmark/results/README.md
+++ b/benchmark/results/README.md
@@ -1,0 +1,34 @@
+# Benchmark — Results Archive (📅 Planned)
+
+> Phase 별 측정 결과의 immutable archive.
+
+## Layout
+
+```
+results/
+├── README.md                    (이 파일)
+└── <YYYY-MM-DD>/                날짜별 측정 batch
+    ├── README.md                — 환경 + 조건 요약
+    ├── mvc-baseline.md          — k6 raw output + Grafana 캡처
+    ├── mvc-coalesced.md
+    ├── redis-multi.md           (Phase 3)
+    ├── webflux-baseline.md      (Phase 6)
+    ├── webflux-coalesced.md
+    └── comparison.md            — 시나리오 간 비교 표
+```
+
+## Why Archive
+
+- 🎯 **재현성** — 미래의 본인이 같은 환경에서 재측정 시 비교 가능
+- 📊 **회귀 추적** — Phase 마다 측정값 변동 추적 (성능 회귀 발견)
+- 🎯 **Portfolio 자료** — 면접에서 cite 가능 ("OK, 정확한 측정 결과는 [results/2026-04-30/mvc-coalesced.md] 에 있습니다")
+
+## Convention
+
+각 측정 batch (`<YYYY-MM-DD>/`) 의 README 에 명시:
+- Hardware spec (CPU, RAM, Docker resource limits)
+- JVM config (heap, GC)
+- Workload (VU, duration, key distribution)
+- 결과 표 (Hypothesis vs Measured)
+- 분석 (왜 그런 결과인지)
+- 다음 액션 (개선점, 추가 측정 필요 영역)

--- a/benchmark/scripts/README.md
+++ b/benchmark/scripts/README.md
@@ -1,0 +1,29 @@
+# Benchmark — Automation Scripts (📅 Planned)
+
+> Phase 별 측정 자동화. Phase 2~6 에 추가됨.
+
+## Planned Scripts
+
+```
+scripts/
+├── run-mvc.sh               (Phase 2) — MVC baseline + coalesced 자동 실행
+├── run-redis-multi.sh       (Phase 3) — 2 인스턴스 setup + 측정
+├── run-webflux.sh           (Phase 6) — WebFlux baseline + coalesced
+├── snapshot-prom.sh         — Prometheus 스냅샷 (날짜별)
+└── compare-results.sh       — 두 결과 file 의 표 비교
+```
+
+## Planned Behavior
+
+각 `run-*.sh` 의 실행 흐름:
+
+```bash
+1. 인프라 health check (docker-compose ps)
+2. 기준선 측정 (warm-up 30s)
+3. k6 baseline 실행 (sustained 60s)
+4. 결과 저장 → benchmark/results/<날짜>/
+5. k6 coalesced 실행 (sustained 60s)
+6. 결과 저장
+7. compare-results.sh 로 표 생성
+8. Grafana snapshot (/api/snapshots) 로 그래프 export
+```

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -1,0 +1,342 @@
+# BENCHMARK — Methodology, Results, and Business Impact Framework
+
+> 측정값은 portfolio 의 무기. 이 문서는 **재현 가능한 측정 방법론** + **paradigm 별 결과** + **비즈니스 임팩트 정량화 framework**.
+>
+> Phase 별 결과는 측정 완료 시점에 채워짐. 현재 일부는 placeholder.
+
+---
+
+## Why Measurement-Driven
+
+Portfolio 의 핵심 원칙 ([THESIS.md](THESIS.md) 참고):
+
+> ❌ "고성능 시스템 만들었어요"
+> ✅ "k6 기준 100 동시 요청 시 외부 호출 100→1, P99 850ms→32ms, Tomcat busy thread 100%→5%"
+
+**측정 가능한 수치만 어필.** 그게 portfolio 가 다른 portfolio 와 차이를 만드는 점.
+
+---
+
+## 공통 벤치마크 규약
+
+모든 Phase 의 측정에 적용. portfolio-docs 의 "공통 벤치마크 규약" 과 일관.
+
+| 항목 | 규약 | 이유 |
+|---|---|---|
+| Warm-up | 측정 전 30초 warm-up, 결과에서 제외 | JIT 컴파일 / 커넥션 풀 / 캐시 hit 안정화 |
+| 측정 시간 | 최소 60초 sustained load | 짧은 burst 는 GC, scheduler 노이즈 반영 못함 |
+| 반복 | 동일 조건 3회 실행, 중앙값 사용 | 단발 측정은 outlier 취약 |
+| 데이터셋 | 트랙별 고정 seed (크기 명시) | 데이터 양에 따라 성능 변화 |
+| 환경 스펙 | docker-compose 리소스 제한값 명시 (CPU/Memory) | "내 맥북에서 돌린 숫자" 에 재현성 부여 |
+| 성공 기준 | 에러율 < 1%, P99 < 목표값 | 높은 TPS 지만 에러율 10% 면 무의미 |
+| 기록 | 환경 + 조건 + 수치 + Grafana 캡처 | 면접에서 "어떤 환경?" 즉답 |
+
+---
+
+## Test Environment
+
+### Hardware (현재 spec — Phase 별 측정 시 갱신)
+
+```
+Host:        Apple Mac M1 / M2 (24GB RAM)
+Docker:      6 CPU / 12GB RAM allocated
+JVM:         OpenJDK 21 (Temurin) / -Xmx512m / -Xms256m / -XX:+UseG1GC
+Spring:      Boot 3.2+
+Tomcat:      max-threads=200 (default)
+```
+
+### Software Stack
+
+```
+Scrap layer:   k6 v0.x (HTTP load)
+Metric collector: Micrometer + Prometheus 2.x
+Visualization: Grafana 10.x
+Backing store: Redis 7.2 (Phase 3+)
+External API simulator: SlowExternalApi (in-process, 500ms 인위 지연)
+```
+
+### Workload Profile
+
+```
+요청 패턴: GET /api/{baseline|coalesced}/expensive?key={K}
+key 분포: 단일 key (worst case for thundering herd)
+부하: VU=100 (k6 virtual users)
+패턴: warm-up 30s + sustained 60s + cool-down 30s
+반복: 3 회, 중앙값 사용
+외부 API 시뮬: 500ms 지연 + 90% 성공률
+```
+
+---
+
+## Phase 1 Results — Library Unit Tests
+
+> 단위 테스트 차원의 정확성 검증. 부하 측정은 Phase 2 부터.
+
+### Coverage
+
+```
+coordinator-core/src/test/
+├── adapter/InProcessSingleFlightCoordinatorTest    [ 7 tests ]
+├── decorator/DeadlineDecoratorTest                  [ 4 tests ]
+├── decorator/CapacityDecoratorTest                  [ 4 tests ]
+├── decorator/HeartbeatDecoratorTest                 [ 3 tests ]
+├── decorator/TelemetryDecoratorTest                 [ 5 tests ]
+└── integration/FullChainTest                        [ 4 tests ]
+                                                    Total: 27 tests
+```
+
+### Performance (단위 테스트 환경)
+
+```
+TBD — Phase 1 완료 후 채움
+```
+
+---
+
+## Phase 2 Results — MVC Demo (Tomcat)
+
+> MVC paradigm 의 thundering herd 표출 + SingleFlight 효과 측정. **"thread pool 보호"** 가 핵심.
+
+### Scenario
+
+```
+Endpoints:
+  GET /api/baseline/expensive?key=K   (no coalesce)
+  GET /api/coalesced/expensive?key=K  (with single-flight)
+
+Workload: 100 VU, 동일 key K, sustained 60s
+External API: 500ms 지연
+```
+
+### Expected Results (Phase 2 완료 시 검증)
+
+| Metric | Baseline | Coalesced | Δ |
+|---|---|---|---|
+| 외부 호출 수 (60s 동안) | ~6,000 | 1 | **6000×** |
+| P50 latency | 500ms | 5ms | 100× |
+| P99 latency | 850ms | 32ms | **26×** |
+| Error rate | < 1% | < 1% | — |
+| Tomcat busy thread (avg) | 100% | 5% | **20× free** |
+| Throughput (req/s) | ~120 | ~3,000 | 25× |
+
+### MVC 의 통점 시각화 (Phase 2 완료 시 Grafana 캡처 첨부)
+
+```
+[ Baseline ]
+Tomcat busy thread:  ████████████████████  100% (200/200)
+External API calls:  ▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲   sustained 100/sec
+P99:                 ━━━━━━━━━━━━━━━━━━━   850ms
+HTTP 503:            ▒▒▒▒                  burst on saturation
+
+[ Coalesced ]
+Tomcat busy thread:  █                     5% (10/200)
+External API calls:  ▲                     1 (only owner)
+P99:                 ▔                     32ms
+HTTP 503:            (none)
+```
+
+→ **MVC paradigm 에선 thread pool 이 자원 병목. SingleFlight 가 thread pool 을 자유롭게 함.**
+
+---
+
+## Phase 3 Results — Multi-instance with Redis
+
+> Multi-instance 환경에서 cross-process coalesce. **"분산 차원에서도 1번"**.
+
+### Scenario
+
+```
+Setup: 2 인스턴스 (mvc-demo-1, mvc-demo-2) behind nginx round-robin
+Backend: Redis SETNX + Pub/Sub
+Workload: 100 VU, 동일 key K, sustained 60s
+```
+
+### Expected Results
+
+| Metric | In-process (단일) | In-process (2 인스턴스) | Redis (2 인스턴스) |
+|---|---|---|---|
+| 외부 호출 수 | 1 | 2 (인스턴스별 race) | **1** |
+| P99 latency | 32ms | 32ms | 38ms (Redis RTT) |
+| Cross-instance coalesce | N/A | ❌ | ✅ |
+| Redis 의존성 | 없음 | 없음 | 있음 (SPOF) |
+
+→ **In-process Map 만으로는 multi-instance 에서 race 발생. Redis layer 필요.**
+
+상세 trade-off: [adr/ADR-002-in-process-vs-redis-lock.md](adr/ADR-002-in-process-vs-redis-lock.md)
+
+---
+
+## Phase 6 Results — WebFlux Demo (Reactor)
+
+> Reactive paradigm 의 thundering herd 표출. **"connection pool 보호"** 가 핵심.
+
+### Scenario
+
+```
+Endpoints:
+  GET /api/flux/baseline/expensive?key=K
+  GET /api/flux/coalesced/expensive?key=K
+
+Workload: 100 VU, 동일 key K, sustained 60s
+External: WebClient (non-blocking) 500ms 지연
+```
+
+### Expected Results
+
+| Metric | Baseline | Coalesced | Δ |
+|---|---|---|---|
+| 외부 호출 수 | ~6,000 | 1 | 6000× |
+| P50 latency | 500ms | 4ms | 125× |
+| P99 latency | 720ms | 28ms | **26×** |
+| WebClient connection (peak) | 100 | 1 | 100× |
+| Reactor scheduler pending | low | low | — |
+| Throughput (req/s) | ~140 | ~3,500 | 25× |
+
+### WebFlux 통점 vs MVC 통점 비교
+
+| 자원 | MVC 표출 | WebFlux 표출 |
+|---|---|---|
+| Thread (worker) | **포화** ★ | 안 막힘 |
+| HTTP connection | (간접) | **포화** ★ |
+| Event loop | N/A | OK |
+| Memory | OK | OK |
+| GC | normal | normal |
+
+→ **같은 thundering herd 인데 서로 다른 자원이 폭주.** 시니어급 깊이.
+
+상세 비교: [cross-paradigm/mvc-vs-webflux.md](cross-paradigm/mvc-vs-webflux.md)
+
+---
+
+## Business Impact Framework
+
+> 기술 메트릭은 시작. **비즈니스 임팩트 정량화** 가 시니어 시그널.
+
+### 정량 임팩트 — 4 차원
+
+#### 1. Customer Support 비용
+
+```
+변수:
+  T_lock      = 평균 lock incident 처리 시간 (분, 실측)
+  N_monthly   = 월간 incident 추정 (실측 × 30)
+  R_cs        = CS 시급 (시장 평균, 회사 정책)
+
+월 CS 비용 = (T_lock / 60) × N_monthly × R_cs
+연간 CS 비용 회피 = 월 CS 비용 × 12
+```
+
+이 incident 적용:
+- T_lock = 14분
+- N_monthly ≈ 150건 (24h 5건 × 30)
+- R_cs = X 원 (NDA)
+- → 월 CS 회피 ≈ N1 원, 연간 ≈ N1 × 12 원
+
+#### 2. Customer Churn 위험
+
+```
+변수:
+  P_churn    = lock incident 후 24h 미접속 비율 (실측)
+  N_monthly  = 월 incident 수 (위와 동일)
+  LTV        = 1인당 평균 매출 (배포 / sub 모델 기준)
+
+월 잠재 churn = P_churn × N_monthly
+월 매출 손실 위험 = 월 잠재 churn × LTV
+```
+
+이 incident 적용:
+- P_churn ≈ 5% (lock 후 24h 미접속)
+- N_monthly = 150
+- 월 잠재 churn = 7.5명
+- 연간 손실 위험 ≈ 90 × LTV
+
+#### 3. 평판 / 신뢰 손상
+
+```
+정성:
+- "새로운 환경 로그인" 메일 5통 → customer 의심 + 비밀번호 변경
+- 변경된 비밀번호 다음 날까지 우리 SaaS 신뢰 손상
+- Customer A 같은 가맹점주 사이 입소문 (negative WOM)
+- 월 영향 customer × 0.X (입소문 multiplier) = 추가 잠재 영향
+```
+
+#### 4. Compliance / Service Continuity 위험
+
+```
+극단 시나리오:
+- 외부 시스템이 차단 정책 강화 → 1시간 → 24시간
+- 누적 차단 → 외부 시스템에서 우리 IP 풀 전체 blacklist
+- → 서비스 전면 중단 시나리오
+
+확률 × 영향 정량화:
+  P_blacklist = 6개월 내 blacklist 발생 확률 (NDA, 정성 추정)
+  Service downtime cost = 시간당 매출 × 평균 복구 시간
+  → 6개월 위험 = P_blacklist × downtime cost
+```
+
+### 합산 회피 가치
+
+```
+연간 회피 ≈ (CS 비용) + (churn 위험) + (평판 multiplier) + (compliance 위험)
+        ≈ 약 N 원 (NDA, 자릿수만 노출 가능)
+```
+
+→ **단순 기술 개선이 아니라 사업 위험 회피.** 면접 어필 핵심.
+
+### 정량화의 portfolio 가치
+
+이 framework 자체가 어필 자산:
+- 면접에서 "비즈니스 임팩트 어떻게 측정?" 물으면 위 framework 인용
+- 실 N 값은 NDA, 사고 방식은 일반화 가능
+
+> ❌ "lock 이 막혔으니 좋은 일"
+> ✅ "월 CS 비용 N1 + 잠재 churn N2 + 평판 손상 + compliance 위험 합산 연간 약 N 원 회피로 추정"
+
+---
+
+## Reproducing the Benchmark
+
+본 repo 의 portfolio 측정은 **누구나 재현 가능**.
+
+```bash
+# 1. 인프라
+cd infra && docker-compose up -d
+
+# 2. MVC Phase 측정
+cd ../benchmark
+bash scripts/run-mvc.sh
+
+# 3. WebFlux Phase 측정
+bash scripts/run-webflux.sh
+
+# 4. Multi-instance Phase 측정
+bash scripts/run-redis-multi.sh
+
+# 5. 결과 비교
+open results/<날짜>/comparison.md
+```
+
+→ 면접관이 본인 환경에서도 같은 측정 가능. 신뢰성 시그널.
+
+---
+
+## Open Questions / TODO
+
+- [ ] Phase 1: 단위 테스트 시간 측정 (microbenchmark)
+- [ ] Phase 2: 실제 측정값 채우기 + Grafana 캡처
+- [ ] Phase 2: GC pressure 비교 (Baseline vs Coalesced)
+- [ ] Phase 3: Redis pub/sub vs polling 결과 전달 비교
+- [ ] Phase 6: Reactor 의 backpressure overflow 시나리오 측정
+- [ ] Phase 6: Mono.cache() vs Sinks.One coalesce 비교
+- [ ] (확장) Phase 7: Loom VT 환경에서 thundering herd 표출
+- [ ] (확장) Phase 8: Coroutines 환경에서 같은 측정
+
+---
+
+## Related
+
+- [STORY.md](STORY.md) — narrative arc
+- [INCIDENT.md](INCIDENT.md) — Customer A timeline
+- [DESIGN.md](DESIGN.md) — Hexagonal + Decorator 설계
+- [INTERVIEW.md](INTERVIEW.md) — 답변 스크립트 (비즈니스 임팩트 답변 cite)
+- portfolio-docs/STRATEGY.md — 공통 벤치마크 규약

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -1,8 +1,12 @@
-# BENCHMARK — Methodology, Results, and Business Impact Framework
+# BENCHMARK — Methodology, Scenarios, and Business Impact Framework
 
-> 측정값은 portfolio 의 무기. 이 문서는 **재현 가능한 측정 방법론** + **paradigm 별 결과** + **비즈니스 임팩트 정량화 framework**.
+> 측정값은 portfolio 의 무기. 이 문서는 **재현 가능한 측정 방법론** + **3 시나리오 분리** + **비즈니스 임팩트 framework**.
 >
-> Phase 별 결과는 측정 완료 시점에 채워짐. 현재 일부는 placeholder.
+> ⚠️ **현재는 narrative skeleton 단계.** 모든 수치는 라벨로 출처 분리:
+> - 🎯 **Hypothesis** — Phase 측정 전 가설 / 목표치
+> - 📊 **Measured** — 실측 (Phase 별 완료 시 갱신, 현재 모두 TBD)
+> - 📂 **Anonymized Production Estimate** — 실 운영 incident 익명화 추정
+> - 📅 **Planned** — 미래 작업 / 환경
 
 ---
 
@@ -11,20 +15,102 @@
 Portfolio 의 핵심 원칙 ([THESIS.md](THESIS.md) 참고):
 
 > ❌ "고성능 시스템 만들었어요"
-> ✅ "k6 기준 100 동시 요청 시 외부 호출 100→1, P99 850ms→32ms, Tomcat busy thread 100%→5%"
+> ✅ "k6 기준 [측정 시나리오 명시] 에서 외부 호출 N→1, P99 850ms→32ms"
 
 **측정 가능한 수치만 어필.** 그게 portfolio 가 다른 portfolio 와 차이를 만드는 점.
 
 ---
 
+## 3 Benchmark Scenarios — Single-Flight 의미론 분리
+
+> **이 단원이 가장 중요.** Single-flight 는 "동시에 inflight 인 동일 key 호출만" 합친다.
+> "60초 sustained 부하 전체를 1회 외부 호출" 은 **single-flight 만으로 불가능**, cache TTL 추가 가정 필요.
+> 시나리오를 명확히 분리해야 가설 / 측정 / 결론이 정확.
+
+### Scenario 1 — Burst Coalescing 🎯
+
+**목적**: 한 instant 에 도착한 동시 N 요청 → 외부 호출 1회 (single-flight 본질).
+
+```
+Workload:
+  100 VU, single burst
+  모두 같은 key K
+  External API: 500ms 지연
+  cache: 비활성 (single-flight 만 측정)
+
+Hypothesis:
+  외부 호출:    1
+  P99 latency: ~500ms (모두 owner 의 응답 기다림)
+  P50:         ~500ms
+  Throughput:  100 / 500ms ≈ 200 req/s
+```
+
+→ 이게 **운영 incident 시나리오의 본질** ([INCIDENT.md](INCIDENT.md)). Customer 의 batch reply 가 1~3초 간격으로 발사되어 80초 안에 20 요청 → owner 진행 중에 다 도착 → coalesce.
+
+### Scenario 2 — Sustained + Cache TTL 🎯
+
+**목적**: 60초 지속 부하 + cache TTL → 외부 호출 ~1회 (cache + single-flight 합산 효과).
+
+```
+Workload:
+  100 VU, sustained 60s
+  같은 key K
+  External API: 500ms 지연
+  cache TTL: 5분 (외부 호출 결과 cache)
+
+Hypothesis:
+  외부 호출:    1 (cache TTL 만료 안 됨)
+  P99 latency: 5ms (cache hit)
+  P50:         3ms
+  Throughput:  ~3,000 req/s (cache 응답 속도)
+```
+
+→ 이게 **흔히 portfolio 가 어필하는 수치**. 단, **cache + single-flight 합산** 이지 single-flight 만의 효과 아님.
+
+### Scenario 3 — Pure Single-Flight (No Cache) 🎯
+
+**목적**: 60초 지속 + cache 비활성 → owner 완료 후 다음 wave 새 owner.
+
+```
+Workload:
+  100 VU, sustained 60s
+  같은 key K
+  External API: 500ms 지연
+  cache: 비활성
+
+Hypothesis:
+  외부 호출:    ~120 (60s ÷ 500ms = 120 successive owners)
+  P99 latency: ~500ms (모두 owner 또는 직후 waiter)
+  P50:         ~500ms
+  Throughput:  ~120 외부 호출에 대해 100 VU 가 분산 → ~ 200 req/s
+```
+
+→ 이게 **순수 single-flight 만의 효과**. cache 가 별도로 풀어주는 게 아닌 영역.
+
+### 비교 요약
+
+| Scenario | 외부 호출 (가설) | P99 (가설) | 적합한 어필 |
+|---|---|---|---|
+| **S1 — Burst** | 1 | ~500ms | Single-flight 본질 시연 |
+| **S2 — Sustained + TTL** | 1 | ~5ms | "프로덕션 스택" 어필 (cache 포함) |
+| **S3 — Pure SF (No Cache)** | ~120 | ~500ms | Single-flight 만의 효과 |
+
+**우리 운영 incident 의 본질은 S1.** Cache 만료 + 동시 burst → 외부 시스템에 distributed login. SF 만으로 충분히 풀림.
+
+**우리 portfolio 어필은 S1 + S2.** S1 은 패턴의 본질, S2 는 production-like 설정.
+
+→ 면접에서 "어떤 scenario 의 측정값?" 즉답해야 시니어 시그널.
+
+---
+
 ## 공통 벤치마크 규약
 
-모든 Phase 의 측정에 적용. portfolio-docs 의 "공통 벤치마크 규약" 과 일관.
+모든 scenario 의 측정에 적용. portfolio-docs 의 "공통 벤치마크 규약" 과 일관.
 
 | 항목 | 규약 | 이유 |
 |---|---|---|
 | Warm-up | 측정 전 30초 warm-up, 결과에서 제외 | JIT 컴파일 / 커넥션 풀 / 캐시 hit 안정화 |
-| 측정 시간 | 최소 60초 sustained load | 짧은 burst 는 GC, scheduler 노이즈 반영 못함 |
+| 측정 시간 | 최소 60초 sustained load (S1 은 burst 모드) | 짧은 burst 는 GC, scheduler 노이즈 반영 못함 |
 | 반복 | 동일 조건 3회 실행, 중앙값 사용 | 단발 측정은 outlier 취약 |
 | 데이터셋 | 트랙별 고정 seed (크기 명시) | 데이터 양에 따라 성능 변화 |
 | 환경 스펙 | docker-compose 리소스 제한값 명시 (CPU/Memory) | "내 맥북에서 돌린 숫자" 에 재현성 부여 |
@@ -33,9 +119,11 @@ Portfolio 의 핵심 원칙 ([THESIS.md](THESIS.md) 참고):
 
 ---
 
-## Test Environment
+## Test Environment 📅
 
-### Hardware (현재 spec — Phase 별 측정 시 갱신)
+> Phase 2 측정 시 검증 + 실 spec 으로 갱신.
+
+### Hardware (예정 spec)
 
 ```
 Host:        Apple Mac M1 / M2 (24GB RAM)
@@ -45,7 +133,7 @@ Spring:      Boot 3.2+
 Tomcat:      max-threads=200 (default)
 ```
 
-### Software Stack
+### Software Stack 📅
 
 ```
 Scrap layer:   k6 v0.x (HTTP load)
@@ -55,24 +143,13 @@ Backing store: Redis 7.2 (Phase 3+)
 External API simulator: SlowExternalApi (in-process, 500ms 인위 지연)
 ```
 
-### Workload Profile
-
-```
-요청 패턴: GET /api/{baseline|coalesced}/expensive?key={K}
-key 분포: 단일 key (worst case for thundering herd)
-부하: VU=100 (k6 virtual users)
-패턴: warm-up 30s + sustained 60s + cool-down 30s
-반복: 3 회, 중앙값 사용
-외부 API 시뮬: 500ms 지연 + 90% 성공률
-```
-
 ---
 
 ## Phase 1 Results — Library Unit Tests
 
 > 단위 테스트 차원의 정확성 검증. 부하 측정은 Phase 2 부터.
 
-### Coverage
+### Coverage 📅
 
 ```
 coordinator-core/src/test/
@@ -85,7 +162,7 @@ coordinator-core/src/test/
                                                     Total: 27 tests
 ```
 
-### Performance (단위 테스트 환경)
+### Performance (단위 테스트 환경) 📊
 
 ```
 TBD — Phase 1 완료 후 채움
@@ -97,102 +174,106 @@ TBD — Phase 1 완료 후 채움
 
 > MVC paradigm 의 thundering herd 표출 + SingleFlight 효과 측정. **"thread pool 보호"** 가 핵심.
 
-### Scenario
+### Scenario 1 (Burst) — MVC Baseline vs Coalesced
 
-```
-Endpoints:
-  GET /api/baseline/expensive?key=K   (no coalesce)
-  GET /api/coalesced/expensive?key=K  (with single-flight)
-
-Workload: 100 VU, 동일 key K, sustained 60s
-External API: 500ms 지연
-```
-
-### Expected Results (Phase 2 완료 시 검증)
-
-| Metric | Baseline | Coalesced | Δ |
+| Metric | Baseline 🎯 | Coalesced 🎯 | Δ (가설) |
 |---|---|---|---|
-| 외부 호출 수 (60s 동안) | ~6,000 | 1 | **6000×** |
-| P50 latency | 500ms | 5ms | 100× |
-| P99 latency | 850ms | 32ms | **26×** |
-| Error rate | < 1% | < 1% | — |
-| Tomcat busy thread (avg) | 100% | 5% | **20× free** |
+| 외부 호출 수 | 100 | 1 | **100×** |
+| P99 latency | ~850ms | ~500ms | 1.7× |
+| Tomcat busy thread (peak) | 100% (200 점유) | 5% (10 점유) | **20× free** |
+| HTTP error rate | < 5% | < 1% | — |
+
+**측정값**: 📊 TBD (Phase 2 완료 시).
+
+### Scenario 2 (Sustained + Cache TTL) — MVC
+
+| Metric | Baseline 🎯 | Coalesced 🎯 | Δ (가설) |
+|---|---|---|---|
+| 외부 호출 수 (60s) | ~6,000 | ~1 | 6000× |
+| P99 latency | 850ms | ~5ms | 170× |
+| P50 latency | 500ms | ~3ms | 167× |
 | Throughput (req/s) | ~120 | ~3,000 | 25× |
 
-### MVC 의 통점 시각화 (Phase 2 완료 시 Grafana 캡처 첨부)
+**측정값**: 📊 TBD.
+
+### Scenario 3 (Pure SF, No Cache) — MVC
+
+| Metric | Baseline 🎯 | Coalesced 🎯 | Δ (가설) |
+|---|---|---|---|
+| 외부 호출 수 (60s) | ~6,000 | ~120 | 50× |
+| P99 latency | 850ms | ~500ms | 1.7× |
+| Tomcat busy thread (avg) | 100% | 60% (owner 들 점유) | 1.7× free |
+
+**측정값**: 📊 TBD.
+
+→ S3 가 "single-flight 만의 효과" 가장 명확.
+
+### MVC 통점 시각화 (Phase 2 완료 시 Grafana 캡처 첨부) 📅
 
 ```
-[ Baseline ]
+[ Baseline — Scenario 2 ]
 Tomcat busy thread:  ████████████████████  100% (200/200)
 External API calls:  ▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲   sustained 100/sec
 P99:                 ━━━━━━━━━━━━━━━━━━━   850ms
 HTTP 503:            ▒▒▒▒                  burst on saturation
 
-[ Coalesced ]
+[ Coalesced — Scenario 2 ]
 Tomcat busy thread:  █                     5% (10/200)
-External API calls:  ▲                     1 (only owner)
-P99:                 ▔                     32ms
+External API calls:  ▲                     1 (only owner, then cache)
+P99:                 ▔                     5ms (cache hit)
 HTTP 503:            (none)
 ```
 
-→ **MVC paradigm 에선 thread pool 이 자원 병목. SingleFlight 가 thread pool 을 자유롭게 함.**
+→ **MVC paradigm 에선 thread pool 이 자원 병목. SingleFlight + cache 가 thread pool 을 자유롭게 함.**
 
 ---
 
-## Phase 3 Results — Multi-instance with Redis
+## Phase 3 Results — Multi-instance with Redis 📅
 
 > Multi-instance 환경에서 cross-process coalesce. **"분산 차원에서도 1번"**.
 
-### Scenario
+### Scenario 1 (Burst) — Multi-instance
 
-```
-Setup: 2 인스턴스 (mvc-demo-1, mvc-demo-2) behind nginx round-robin
-Backend: Redis SETNX + Pub/Sub
-Workload: 100 VU, 동일 key K, sustained 60s
-```
-
-### Expected Results
-
-| Metric | In-process (단일) | In-process (2 인스턴스) | Redis (2 인스턴스) |
+| Metric | InProcess 단일 🎯 | InProcess 2 인스턴스 🎯 | Redis 2 인스턴스 🎯 |
 |---|---|---|---|
 | 외부 호출 수 | 1 | 2 (인스턴스별 race) | **1** |
-| P99 latency | 32ms | 32ms | 38ms (Redis RTT) |
+| P99 latency | ~500ms | ~500ms | ~510ms (Redis RTT) |
 | Cross-instance coalesce | N/A | ❌ | ✅ |
-| Redis 의존성 | 없음 | 없음 | 있음 (SPOF) |
+
+**측정값**: 📊 TBD.
 
 → **In-process Map 만으로는 multi-instance 에서 race 발생. Redis layer 필요.**
 
-상세 trade-off: [adr/ADR-002-in-process-vs-redis-lock.md](adr/ADR-002-in-process-vs-redis-lock.md)
+상세 trade-off: [adr/ADR-002-in-process-vs-redis-lock.md](adr/ADR-002-in-process-vs-redis-lock.md) (Phase 3 시 작성)
 
 ---
 
-## Phase 6 Results — WebFlux Demo (Reactor)
+## Phase 6 Results — WebFlux Demo (Reactor) 📅
 
 > Reactive paradigm 의 thundering herd 표출. **"connection pool 보호"** 가 핵심.
 
-### Scenario
+### Scenario 1 (Burst) — WebFlux Baseline vs Coalesced
 
-```
-Endpoints:
-  GET /api/flux/baseline/expensive?key=K
-  GET /api/flux/coalesced/expensive?key=K
-
-Workload: 100 VU, 동일 key K, sustained 60s
-External: WebClient (non-blocking) 500ms 지연
-```
-
-### Expected Results
-
-| Metric | Baseline | Coalesced | Δ |
+| Metric | Baseline 🎯 | Coalesced 🎯 | Δ (가설) |
 |---|---|---|---|
-| 외부 호출 수 | ~6,000 | 1 | 6000× |
-| P50 latency | 500ms | 4ms | 125× |
-| P99 latency | 720ms | 28ms | **26×** |
+| 외부 호출 수 | 100 | 1 | 100× |
+| P99 latency | ~720ms | ~500ms | 1.4× |
 | WebClient connection (peak) | 100 | 1 | 100× |
 | Reactor scheduler pending | low | low | — |
-| Throughput (req/s) | ~140 | ~3,500 | 25× |
 
-### WebFlux 통점 vs MVC 통점 비교
+**측정값**: 📊 TBD.
+
+### Scenario 2 (Sustained + TTL) — WebFlux
+
+| Metric | Baseline 🎯 | Coalesced 🎯 |
+|---|---|---|
+| 외부 호출 수 (60s) | ~6,000 | ~1 |
+| P99 latency | 720ms | ~4ms |
+| Throughput (req/s) | ~140 | ~3,500 |
+
+**측정값**: 📊 TBD.
+
+### WebFlux vs MVC 통점 비교
 
 | 자원 | MVC 표출 | WebFlux 표출 |
 |---|---|---|
@@ -204,7 +285,31 @@ External: WebClient (non-blocking) 500ms 지연
 
 → **같은 thundering herd 인데 서로 다른 자원이 폭주.** 시니어급 깊이.
 
-상세 비교: [cross-paradigm/mvc-vs-webflux.md](cross-paradigm/mvc-vs-webflux.md)
+상세 비교: [cross-paradigm/mvc-vs-webflux.md](cross-paradigm/mvc-vs-webflux.md) (Phase 6 측정 후 채워짐)
+
+---
+
+## Production Incident — Anonymized Estimate 📂
+
+> 운영 incident ([INCIDENT.md](INCIDENT.md)) 의 익명화 추정값.
+> **합성 벤치 (Phase 2~6) 측정값과 다름.** 운영 환경 = 외부 SaaS + 실 customer + 프록시 풀 + 인증 + 변동 부하.
+
+### Operational Impact 📂
+
+| 항목 | Before (without single-flight) | After (with single-flight) |
+|---|---|---|
+| 외부 호출 (동시 20 요청) | 20 | 1 |
+| 다른 IP 할당 (80초 윈도우) | 10 | 1 |
+| 외부 시스템 보안 차단 | 발생 | 0 (24h 모니터링) |
+| 영향받은 customer (24h) | 5 명 | 0 명 |
+
+→ 이 수치는 **운영 환경 추정**. 합성 벤치로 정확히 재현되지 않음 (외부 환경 통제 불가).
+
+P99 850ms→32ms 같은 latency 수치는 **합성 벤치의 가설** (이 문서의 Scenario 2 표 참고). 운영 latency 는 외부 SaaS 응답 변동성 등 추가 변수.
+
+→ 면접 답변 시 라벨 분리 필수:
+- "운영 추정값" — 외부 호출 / IP 할당 / 차단 incident 수
+- "합성 벤치 가설 / 측정값" — P99 / Tomcat busy / connection pool
 
 ---
 
@@ -226,7 +331,7 @@ External: WebClient (non-blocking) 500ms 지연
 연간 CS 비용 회피 = 월 CS 비용 × 12
 ```
 
-이 incident 적용:
+이 incident 적용 (📂 anonymized estimate):
 - T_lock = 14분
 - N_monthly ≈ 150건 (24h 5건 × 30)
 - R_cs = X 원 (NDA)
@@ -244,7 +349,7 @@ External: WebClient (non-blocking) 500ms 지연
 월 매출 손실 위험 = 월 잠재 churn × LTV
 ```
 
-이 incident 적용:
+이 incident 적용 (📂 anonymized estimate):
 - P_churn ≈ 5% (lock 후 24h 미접속)
 - N_monthly = 150
 - 월 잠재 churn = 7.5명
@@ -274,7 +379,7 @@ External: WebClient (non-blocking) 500ms 지연
   → 6개월 위험 = P_blacklist × downtime cost
 ```
 
-### 합산 회피 가치
+### 합산 회피 가치 📂
 
 ```
 연간 회피 ≈ (CS 비용) + (churn 위험) + (평판 multiplier) + (compliance 위험)
@@ -294,33 +399,31 @@ External: WebClient (non-blocking) 500ms 지연
 
 ---
 
-## Reproducing the Benchmark
+## Reproducing the Benchmark 📅
 
-본 repo 의 portfolio 측정은 **누구나 재현 가능**.
+> 본 repo 의 측정 자동화는 **Phase 별 진행 시 채워짐**. 현재는 예정 명령.
+> 실제 동작은 [benchmark/](../benchmark/) 와 [infra/](../infra/) 의 Phase 별 placeholder README 참고.
 
 ```bash
-# 1. 인프라
+# Phase 2 완료 후 동작 예정:
 cd infra && docker-compose up -d
+cd ../benchmark && bash scripts/run-mvc.sh
 
-# 2. MVC Phase 측정
-cd ../benchmark
-bash scripts/run-mvc.sh
-
-# 3. WebFlux Phase 측정
-bash scripts/run-webflux.sh
-
-# 4. Multi-instance Phase 측정
+# Phase 3 완료 후:
 bash scripts/run-redis-multi.sh
 
-# 5. 결과 비교
+# Phase 6 완료 후:
+bash scripts/run-webflux.sh
+
+# 결과 비교:
 open results/<날짜>/comparison.md
 ```
 
-→ 면접관이 본인 환경에서도 같은 측정 가능. 신뢰성 시그널.
+→ 면접관이 본인 환경에서도 같은 측정 가능 — **단 Phase 진행 후**. 신뢰성 시그널.
 
 ---
 
-## Open Questions / TODO
+## Open Questions / TODO 📅
 
 - [ ] Phase 1: 단위 테스트 시간 측정 (microbenchmark)
 - [ ] Phase 2: 실제 측정값 채우기 + Grafana 캡처
@@ -335,8 +438,8 @@ open results/<날짜>/comparison.md
 
 ## Related
 
-- [STORY.md](STORY.md) — narrative arc
-- [INCIDENT.md](INCIDENT.md) — Customer A timeline
+- [STORY.md](STORY.md) — narrative arc (운영 추정값 명시)
+- [INCIDENT.md](INCIDENT.md) — Customer A timeline (📂 운영 데이터 anonymized)
 - [DESIGN.md](DESIGN.md) — Hexagonal + Decorator 설계
-- [INTERVIEW.md](INTERVIEW.md) — 답변 스크립트 (비즈니스 임팩트 답변 cite)
+- [INTERVIEW.md](INTERVIEW.md) — 답변 스크립트 (라벨 분리 적용)
 - portfolio-docs/STRATEGY.md — 공통 벤치마크 규약

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -10,11 +10,69 @@
 
 **Hexagonal Architecture (Port & Adapter) + Decorator Pattern (GoF)** 의 합성.
 
-이유:
-1. **Backend swap** 가능 (in-process Map ↔ Redis ↔ MQ) without 도메인 코드 수정
-2. **Cross-cutting concern 분리** (telemetry, deadline, capacity, heartbeat)
-3. **테스트 격리** (각 layer 독립 단위 테스트)
-4. **Composition flexibility** (필요한 decorator 만 stack)
+### Why this style — 4 시그널 검증
+
+Hexagonal 은 항상 정답이 아님. 다음 4 시그널 중 **2 개 이상** 해당해야 추상화 비용이 정당화.
+
+| 시그널 | 우리 case 적용? |
+|---|:---:|
+| **여러 backend 가 실제 필요** | ✅ Phase 3 (Redis) 명시 + 미래 MQ routing |
+| **도메인 코드 (NaverService) 가 인프라 변경 영향 X** | ✅ Port 만 의존 |
+| **Port API 가 안정적** | ✅ 4 메서드 (Phase 1~6 동안 변동 없을 예정) |
+| **Framework 독립성** | ✅ coordinator-core 가 Spring 의존성 0 |
+
+**4/4 해당** → Hexagonal 채택 정당화 충분.
+
+### When NOT to use this style
+
+다음 anti-signal 중 2개 이상 해당하면 [Alternative — 단순 utility class](#alternative-simple-utility-30-lines) 가 정답:
+
+| Anti-signal | 우리 case 적용? |
+|---|:---:|
+| 단일 backend 평생 쓸 가능성 높음 | ❌ |
+| Port 가 thin pass-through (변환 / 정책 layer 없음) | ❌ |
+| 팀 작고 코드베이스 작고 변경 빈도 낮음 | 부분 |
+| Framework 강결합 OK (평생 Spring 만) | ❌ |
+
+→ **0~1 anti-signal 해당.** Hexagonal 의 추상화 비용이 가치 미만 아님.
+
+상세 cost-benefit 분석 + Decision Matrix: [adr/ADR-001-port-adapter-pattern.md](adr/ADR-001-port-adapter-pattern.md#decision-signals--왜-이-case-가-hexagonal-정당화되는가)
+
+### Trade-offs we knowingly accept
+
+이 architectural 선택의 **명시적 비용**:
+
+- ❌ **약 1000 줄 추가** (단순 inline utility 30줄 대비 30× 코드)
+- ❌ **추상화 학습 비용** (새 팀원이 chain 이해하는 데 2-3시간)
+- ❌ **DI 설정 복잡** (factory 함수에서 5 layer 합성 명시)
+- ❌ **간접화 디버깅** (stack trace 가 5 layer 거침)
+
+이 비용을 받아들이는 이유:
+- **Phase 3 Redis transition 시 NaverService 수정 0** (절약 ~2일)
+- **다른 도메인 (CPEATS, BAEMIN) 재사용** (절약 ~5일/도메인)
+- **테스트 격리** (각 layer 독립 디버깅)
+- **Portfolio 어필** (architectural depth 시그널)
+
+→ **Phase 3 의 Redis adapter 가 첫 번째 ROI 검증 포인트.** 만약 거기서 Port 시그니처 변경이 필요해지면 추상화 한계 인식하고 ADR-001 revision.
+
+### Alternative — Simple Utility (30 lines)
+
+만약 위 4 시그널이 0~1 개만 해당했다면:
+
+```java
+@Service
+public class NaverService {
+    private final ConcurrentHashMap<String, CompletableFuture<Session>> inflight = new ConcurrentHashMap<>();
+
+    public CompletableFuture<Session> ensureSession(String userId) {
+        return inflight.computeIfAbsent(userId, k ->
+            doEnsureSession(k).whenComplete((v, e) -> inflight.remove(k))
+        );
+    }
+}
+```
+
+이게 **시니어 정답**. YAGNI 정직하게 따름. Hexagonal 자체에 대한 고집은 cargo cult.
 
 상세 결정 근거: [adr/ADR-001-port-adapter-pattern.md](adr/ADR-001-port-adapter-pattern.md)
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -225,7 +225,7 @@ Telemetry   ← 로그 / 메트릭 (outermost)
 
 ### Decorator 1 — Deadline
 
-**책임**: hard wall-clock 타임아웃. 도달 시 owner + 모든 waiter 강제 reject.
+**책임**: hard wall-clock 타임아웃. 도달 시 **CompletableFuture 차원에서** owner + 모든 waiter 가 같은 `TimeoutException` 받음.
 
 ```java
 public class DeadlineDecorator implements SingleFlightCoordinator {
@@ -248,25 +248,77 @@ public class DeadlineDecorator implements SingleFlightCoordinator {
 
 **Java 21 의 `CompletableFuture.orTimeout`** — TS 의 `Promise.race(op, timer)` 보다 우아.
 
+#### ⚠️ 중요한 nuance — "Future timeout" vs "실제 작업 cancellation"
+
+`orTimeout` 은 **CompletableFuture 만 timeout** 시킴:
+- ✅ 모든 callers (owner + waiter) 가 `TimeoutException` 받음 (예외 전파 정확)
+- ✅ Inflight 엔트리는 `whenComplete` cleanup 으로 제거됨
+- ❌ **underlying 작업 (Playwright session, Redis call 등) 은 cancel 안 됨**
+- ❌ Orphaned 작업이 백그라운드에서 계속 진행 → **자원 leak 위험**
+
+**자원 cleanup 책임 분리**:
+- Coordinator 는 future-level 보호만 담당
+- 실 작업의 cleanup 은 **operation 본체** 에서 `try-finally` / `whenComplete` / `Cleaner` 로 명시적 처리
+- 예: NaverService 의 `ensureSession` 은 timeout 시 `closePage(userId)` 호출하는 finally hook
+
+→ Phase 1 코드에서 이 분리를 명시적으로 시연. ADR-001 의 Implementation Notes 참고.
+
 ### Decorator 2 — Capacity
 
 **책임**: 동일 key 의 waiter 수가 cap (default 30) 도달 시 새 호출 즉시 reject.
 
+#### ⚠️ Atomicity 주의 — 두 단계 검사는 race condition
+
+순진한 구현 (race condition 가능):
 ```java
+// ❌ 이건 race 가능
 @Override
 public <T> CompletableFuture<T> execute(String key, Supplier<CompletableFuture<T>> op,
                                          SingleFlightOptions options) {
-    int max = options.maxWaiters().orElse(defaultMax);
-    int current = countWaiters(key);
-
-    if (current >= max) {
-        return CompletableFuture.failedFuture(
-            new CongestionException(key, current, max)
-        );
-    }
-    return inner.execute(key, op, options);
+    int current = inner.getInflightState().find(key).waiterCount;  // (1) read
+    if (current >= max) throw new CongestionException(...);
+    return inner.execute(key, op, options);  // (2) attach — 사이에 다른 thread 진입 가능
 }
 ```
+
+(1) read 와 (2) attach 사이에 다른 thread 가 들어오면 cap 31, 32 도 통과 가능.
+
+**올바른 atomic 구현**: capacity 검사를 base record 에 박음.
+
+```java
+// ✅ 올바른 방식 — base 의 atomic record 안에 cap check
+public class InProcessSingleFlightCoordinator implements SingleFlightCoordinator {
+    @Override
+    public <T> CompletableFuture<T> execute(String key, Supplier<CompletableFuture<T>> op,
+                                             SingleFlightOptions options) {
+        int max = options.maxWaiters().orElse(Integer.MAX_VALUE);
+
+        return inflight.compute(key, (k, existing) -> {
+            if (existing != null) {
+                if (existing.waiterCount.incrementAndGet() > max) {
+                    existing.waiterCount.decrementAndGet();
+                    throw new CongestionException(key, max, max);
+                }
+                return existing;
+            }
+            // 새 owner
+            CompletableFuture<T> future = op.get().whenComplete((v, e) -> inflight.remove(k));
+            return new InflightRecord<>(k, future, new AtomicInteger(1));
+        }).future;
+    }
+}
+```
+
+→ **Capacity 검사가 base record 의 atomic compute 안에서.** Decorator 가 아닌 base 의 책임으로 이동.
+
+**Decorator 의 역할** 은 cap 의 default 값 / option 처리 / telemetry 정도로 한정. 진짜 atomic 검사는 base 가 책임.
+
+→ Phase 1 코드에서 이 atomic 보장을 명시적으로 구현. 단위 테스트의 race scenario 가 검증 포인트.
+
+이 구조의 trade-off:
+- ✅ Cap 정확 보장 (race-free)
+- ❌ Decorator 의 SRP 살짝 약화 (capacity 가 base 와 결합)
+- → ADR-001 의 "When NOT to use" 에서 언급한 "Anti-Signal A2: Port 가 thin pass-through" 로 가는 경향. 실용적 타협.
 
 → UI spam 방어. 이미 attached waiter 는 영향 없음, 신규 호출만 차단.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,429 @@
+# DESIGN — Hexagonal Architecture + Decorator Stack
+
+> Single-Flight Coordinator 의 architectural 설계. **왜 이 구조인지** + **각 layer 의 책임**.
+>
+> 코드 구현은 [coordinator-core/](../coordinator-core/) 에서 진행. 결정 근거는 [adr/](adr/).
+
+---
+
+## Architectural Style
+
+**Hexagonal Architecture (Port & Adapter) + Decorator Pattern (GoF)** 의 합성.
+
+이유:
+1. **Backend swap** 가능 (in-process Map ↔ Redis ↔ MQ) without 도메인 코드 수정
+2. **Cross-cutting concern 분리** (telemetry, deadline, capacity, heartbeat)
+3. **테스트 격리** (각 layer 독립 단위 테스트)
+4. **Composition flexibility** (필요한 decorator 만 stack)
+
+상세 결정 근거: [adr/ADR-001-port-adapter-pattern.md](adr/ADR-001-port-adapter-pattern.md)
+
+---
+
+## High-Level Architecture
+
+```mermaid
+graph TD
+    A[Domain Service<br/>e.g. NaverService.ensureSession]
+    B[SingleFlightCoordinator<br/>Port / Interface]
+    C[TelemetryDecorator<br/>로그 / 메트릭 / waiter count]
+    D[HeartbeatDecorator<br/>60s+ 진행 중 entry 경고]
+    E[CapacityDecorator<br/>30+ waiter 거부]
+    F[DeadlineDecorator<br/>180s wall-clock 타임아웃]
+    G[InProcessSingleFlightCoordinator<br/>ConcurrentHashMap.computeIfAbsent]
+    H[ensureSessionImpl<br/>Playwright 영역]
+
+    A -->|depends on Port| B
+    B -.->|implements| C
+    C -->|inner| D
+    D -->|inner| E
+    E -->|inner| F
+    F -->|inner| G
+    G -->|operation()| H
+
+    style A fill:#f9f,stroke:#333,stroke-width:2px
+    style B fill:#bbf,stroke:#333,stroke-width:2px,color:#000
+    style G fill:#9f9,stroke:#333,stroke-width:2px,color:#000
+    style H fill:#fc9,stroke:#333,stroke-width:2px,color:#000
+```
+
+**Reading the diagram**:
+- 위에서 아래로 호출이 흐름 (delegation)
+- 각 layer 가 같은 인터페이스 (`SingleFlightCoordinator`) 구현
+- Domain service (NaverService) 는 인터페이스만 의존 → 구현 디테일 invisible
+- Backend (InProcess) 가 chain 의 종착점
+
+---
+
+## The Port — `SingleFlightCoordinator`
+
+### Interface
+
+```java
+public interface SingleFlightCoordinator {
+    /** 동시 호출 시 1 owner + N waiter 로 합침 */
+    <T> CompletableFuture<T> execute(
+        String key,
+        Supplier<CompletableFuture<T>> operation
+    );
+
+    /** 옵션 (deadline, maxWaiters, telemetryTag) 포함 버전 */
+    <T> CompletableFuture<T> execute(
+        String key,
+        Supplier<CompletableFuture<T>> operation,
+        SingleFlightOptions options
+    );
+
+    /** 진행 중 entry snapshot — heartbeat / 운영 도구용 */
+    List<InflightEntry> getInflightState();
+
+    /** 운영 kill switch — 강제로 entry 제거 + waiter reject */
+    CompletableFuture<Void> forceRelease(String key, String reason);
+}
+```
+
+### Why This Shape
+
+- **`Supplier<CompletableFuture<T>>`** — operation 을 lazy 하게 평가 (재시도 / 지연 가능)
+- **`String key`** — 도메인 의미 (userId, cacheKey, ...) 의 직렬화. 모든 backend 가 string 키 지원
+- **`SingleFlightOptions`** — 호출별 정책 override (decorator 가 해석)
+- **`getInflightState`** — observability + heartbeat decorator 의 의존
+- **`forceRelease`** — 운영 escape hatch (stuck owner 강제 종료)
+
+### What This Port Hides
+
+- 어느 backend 인지 (InProcess / Redis / MQ)
+- Lock 메커니즘 (computeIfAbsent / SETNX / per-key queue)
+- 결과 전달 방식 (Promise sharing / pub-sub / reply-to)
+- Cleanup 전략 (.finally / TTL expire / explicit release)
+
+→ 도메인 service 는 이 모든 디테일에 무관. backend 갈아끼우면 도메인 service 수정 0.
+
+---
+
+## The Base Adapter — `InProcessSingleFlightCoordinator`
+
+### Implementation Sketch
+
+```java
+public class InProcessSingleFlightCoordinator implements SingleFlightCoordinator {
+
+    private final ConcurrentHashMap<String, InflightRecord<?>> inflight = new ConcurrentHashMap<>();
+
+    @Override
+    public <T> CompletableFuture<T> execute(String key, Supplier<CompletableFuture<T>> operation) {
+        @SuppressWarnings("unchecked")
+        InflightRecord<T> record = (InflightRecord<T>) inflight.computeIfAbsent(key, k -> {
+            CompletableFuture<T> future = operation.get();
+            future.whenComplete((v, e) -> inflight.remove(k));
+            return new InflightRecord<>(k, future, System.currentTimeMillis());
+        });
+        return record.future();
+    }
+
+    /* getInflightState, forceRelease 생략 */
+}
+
+record InflightRecord<T>(String key, CompletableFuture<T> future, long startedAt) {}
+```
+
+### Why `ConcurrentHashMap.computeIfAbsent`
+
+- **Atomic**: "없으면 만들고 있으면 반환" 이 하나의 atomic operation
+- **No race**: TS 의 `Promise.race + .then(set)` 처럼 race 가능성 없음
+- **Cleanup via whenComplete**: future 가 settle 되면 자동 entry 제거
+- **Type-safe with cast**: `<T>` 가 generic 이라 cast 1 곳에 격리
+
+### Trade-offs
+
+✅ Latency 0.1ms 미만 (메모리 lookup)
+✅ 단순 — JVM 내장 primitive
+❌ 단일 process 한정 (멀티 인스턴스 시 cross-instance race)
+❌ Process crash 시 모든 inflight 손실 (waiter 들 timeout 으로 fail)
+
+→ 단일 인스턴스 환경의 default. 멀티 인스턴스는 [adr/ADR-002-in-process-vs-redis-lock.md](adr/ADR-002-in-process-vs-redis-lock.md).
+
+---
+
+## The Decorator Stack
+
+각 decorator 는 같은 `SingleFlightCoordinator` 인터페이스 구현. **단일 책임 원칙 (SRP)** 으로 분리.
+
+### Stack Order (inner → outer)
+
+```
+Base (InProcess)
+  ↓
+Deadline    ← hard timeout
+  ↓
+Capacity    ← waiter cap
+  ↓
+Heartbeat   ← stuck 감지
+  ↓
+Telemetry   ← 로그 / 메트릭 (outermost)
+```
+
+순서가 의미 있음 — 자세한 근거는 [adr/ADR-003-decorator-stack-order.md](adr/ADR-003-decorator-stack-order.md).
+
+### Decorator 1 — Deadline
+
+**책임**: hard wall-clock 타임아웃. 도달 시 owner + 모든 waiter 강제 reject.
+
+```java
+public class DeadlineDecorator implements SingleFlightCoordinator {
+    private final SingleFlightCoordinator inner;
+    private final Duration defaultDeadline;
+
+    @Override
+    public <T> CompletableFuture<T> execute(String key, Supplier<CompletableFuture<T>> op,
+                                             SingleFlightOptions options) {
+        Duration deadline = options.deadlineMs()
+            .map(Duration::ofMillis)
+            .orElse(defaultDeadline);
+
+        return inner.execute(key, () ->
+            op.get().orTimeout(deadline.toMillis(), TimeUnit.MILLISECONDS)
+        , options);
+    }
+}
+```
+
+**Java 21 의 `CompletableFuture.orTimeout`** — TS 의 `Promise.race(op, timer)` 보다 우아.
+
+### Decorator 2 — Capacity
+
+**책임**: 동일 key 의 waiter 수가 cap (default 30) 도달 시 새 호출 즉시 reject.
+
+```java
+@Override
+public <T> CompletableFuture<T> execute(String key, Supplier<CompletableFuture<T>> op,
+                                         SingleFlightOptions options) {
+    int max = options.maxWaiters().orElse(defaultMax);
+    int current = countWaiters(key);
+
+    if (current >= max) {
+        return CompletableFuture.failedFuture(
+            new CongestionException(key, current, max)
+        );
+    }
+    return inner.execute(key, op, options);
+}
+```
+
+→ UI spam 방어. 이미 attached waiter 는 영향 없음, 신규 호출만 차단.
+
+### Decorator 3 — Heartbeat
+
+**책임**: `ScheduledExecutorService` 로 15초 간격 스캔. 60초+ 진행 중 entry 발견 시 `long_running` warn 로그.
+
+```java
+public void onModuleInit() {
+    scheduler.scheduleAtFixedRate(this::scanLongRunning, 15, 15, TimeUnit.SECONDS);
+}
+
+private void scanLongRunning() {
+    long now = System.currentTimeMillis();
+    inner.getInflightState().stream()
+        .filter(e -> now - e.startedAt() >= 60_000)
+        .forEach(e -> logger.warn("long_running key={} ageMs={}", e.key(), now - e.startedAt()));
+}
+```
+
+→ 운영자에게 stuck 가능성 사전 알림. Deadline 도달 전에 수동 개입 가능.
+
+### Decorator 4 — Telemetry (outermost)
+
+**책임**: 모든 호출의 로그 + 메트릭. waiter count, owner duration, status (success/failure/deadline/congestion).
+
+```java
+@Override
+public <T> CompletableFuture<T> execute(String key, Supplier<CompletableFuture<T>> op,
+                                         SingleFlightOptions options) {
+    String tag = options.telemetryTag().orElse("default");
+    long start = System.currentTimeMillis();
+
+    return inner.execute(key, op, options)
+        .whenComplete((v, e) -> {
+            long duration = System.currentTimeMillis() - start;
+            String status = classifyStatus(e);
+            metrics.histogram("singleflight_owner_duration_ms",
+                Map.of("tag", tag, "status", status), duration);
+            logger.info("[SingleFlight] tag={} event=owner_finished status={} key={} durationMs={}",
+                tag, status, key, duration);
+        });
+}
+```
+
+**왜 outermost?** Deadline 이 throw 한 `DeadlineExceededException` 을 분류해서 `status=deadline` 으로 메트릭 찍어야 하기 때문. Telemetry 가 안쪽이면 deadline exception 이 보이지 않음.
+
+→ [adr/ADR-003-decorator-stack-order.md](adr/ADR-003-decorator-stack-order.md) 참고.
+
+---
+
+## Sequence Diagram — 동시 N 호출
+
+```mermaid
+sequenceDiagram
+    participant C1 as Caller 1
+    participant C2 as Caller 2
+    participant C3 as Caller 3
+    participant T as TelemetryDecorator
+    participant H as HeartbeatDecorator
+    participant Cap as CapacityDecorator
+    participant D as DeadlineDecorator
+    participant B as Base (InProcess)
+    participant Op as ensureSessionImpl
+
+    C1->>T: execute("user-X", op)
+    T->>H: pass-through
+    H->>Cap: pass-through
+    Cap->>Cap: capacity check (1 waiter)
+    Cap->>D: pass-through
+    D->>D: wrap with timeout
+    D->>B: execute("user-X", wrapped)
+    B->>B: computeIfAbsent("user-X")
+    B->>Op: operation.get() — 1번만
+    Note over Op: Playwright login (~3초)
+
+    C2->>T: execute("user-X", op)
+    T->>H: pass-through
+    H->>Cap: pass-through
+    Cap->>Cap: capacity check (2 waiters)
+    Cap->>D: pass-through
+    D->>B: execute("user-X", wrapped)
+    B->>B: computeIfAbsent — 기존 record
+    B-->>C2: 같은 future 공유
+
+    C3->>T: execute("user-X", op)
+    T-->>C3: 같은 future 공유 (3 waiters)
+
+    Op->>B: future.complete(session)
+    B->>B: whenComplete cleanup → remove("user-X")
+    B-->>D: session
+    D-->>Cap: session
+    Cap-->>H: session
+    H-->>T: session
+    T->>T: log + metric (waiterCount=3)
+    T-->>C1: session
+    T-->>C2: session
+    T-->>C3: session
+```
+
+**핵심 관찰**:
+- Operation 은 **1번만 실행** (`Op` 박스)
+- 3 caller 모두 같은 `CompletableFuture` 공유
+- Cleanup 은 future settle 시 자동 (`whenComplete`)
+- Telemetry 가 outermost 라 모든 caller 에 대해 통계 정확
+
+---
+
+## Module Layout
+
+```
+single-flight-coordinator-lab/
+├── coordinator-core/                    Pure Java 라이브러리
+│   └── src/main/java/com/portfolio/singleflight/
+│       └── coordinator/
+│           ├── SingleFlightCoordinator.java       (Port)
+│           ├── SingleFlightOptions.java
+│           ├── InflightEntry.java
+│           ├── adapter/
+│           │   ├── InProcessSingleFlightCoordinator.java
+│           │   └── RedisSingleFlightCoordinator.java        (Phase 3)
+│           ├── decorator/
+│           │   ├── DeadlineDecorator.java
+│           │   ├── CapacityDecorator.java
+│           │   ├── HeartbeatDecorator.java
+│           │   └── TelemetryDecorator.java
+│           ├── exception/
+│           │   ├── DeadlineExceededException.java
+│           │   ├── CongestionException.java
+│           │   └── ForceReleasedException.java
+│           └── observability/
+│               └── MetricSink.java                 (Micrometer 추상화)
+│
+├── mvc-demo/                            Spring MVC + Tomcat (Phase 2)
+├── webflux-demo/                        Spring WebFlux + Reactor (Phase 6)
+└── reference/ts-impl/                   TypeScript 참조 구현 (Phase 4)
+```
+
+---
+
+## Backend Variants — Future Adapters
+
+### InProcess (Phase 1) — 현재
+- 단일 JVM 한정
+- `ConcurrentHashMap.computeIfAbsent`
+
+### Redis (Phase 3) — 확장
+- 멀티 인스턴스 cross-coalesce
+- `SETNX + Lua release + Pub/Sub result broadcast`
+
+### MQ Routing (미래, RFC)
+- 인스턴스 간 요청 라우팅 (consistent hash)
+- 같은 user 의 요청은 같은 인스턴스로 → 자연스럽게 in-process 로 coalesce
+- 단 InProcess Coordinator 와 합성 (대체 아님)
+
+---
+
+## Decorator Pattern — Why GoF over Spring AOP
+
+대안 검토:
+
+### Spring AOP `@Around`
+✅ 익숙
+✅ Bean 단위 적용
+❌ proxy chain 의 디버깅 어려움
+❌ Spring 의존성 (coordinator-core 가 Spring 0)
+❌ 적용 순서 명시적이지 않음
+
+### Decorator Pattern (우리 선택)
+✅ 명시적 stack 순서
+✅ Spring 무관 (Pure Java)
+✅ 단위 테스트 격리 자연스러움
+✅ DI factory 에서 합성 명시
+
+→ coordinator-core 가 framework-independent 라 Pattern 우선.
+
+---
+
+## Failure Modes
+
+각 layer 의 failure 시나리오:
+
+| Failure | 표출 | Recovery |
+|---|---|---|
+| Operation throws | future fails → all waiters get same exception | InProcess `whenComplete` cleanup, next call 새 owner |
+| Deadline exceeded | `DeadlineExceededException` → all waiters fail | InProcess cleanup, next call 새 owner |
+| Capacity full | 신규 호출만 `CongestionException`, 기존 waiter 영향 없음 | 기존 owner 끝나면 자동 정상화 |
+| InProcess: ownership lost | 거의 불가능 (computeIfAbsent atomic) | — |
+| Redis: lock TTL 만료 | 다른 인스턴스가 lock 인수 | TTL 튜닝 |
+| Redis: Pub/Sub 누락 | waiter 가 polling fallback | Phase 3 에서 시연 |
+| forceRelease called | `ForceReleasedException` to all waiters | 운영 escape hatch |
+
+---
+
+## Performance Characteristics
+
+| Operation | Time | Notes |
+|---|---|---|
+| `execute` first call | 1 microtask + computeIfAbsent | ~1μs overhead |
+| `execute` waiter (already inflight) | 1 computeIfAbsent | ~0.5μs overhead |
+| `getInflightState` | O(n) scan | n = inflight entries (보통 < 100) |
+| `forceRelease` | O(1) | atomic remove |
+| Heartbeat scan | O(n), 15s 간격 | n 작으니 무시 |
+
+→ Coalescing 자체의 overhead 는 micro-second. 비싼 외부 호출 (밀리초~초) 대비 무시 가능.
+
+---
+
+## Related
+
+- [STORY.md](STORY.md) — 전체 narrative
+- [INCIDENT.md](INCIDENT.md) — 이 설계가 풀어야 했던 incident
+- [BENCHMARK.md](BENCHMARK.md) — 측정 방법론 + 결과
+- [adr/ADR-001-port-adapter-pattern.md](adr/ADR-001-port-adapter-pattern.md) — Port/Adapter 채택 근거
+- [adr/ADR-002-in-process-vs-redis-lock.md](adr/ADR-002-in-process-vs-redis-lock.md) — Backend 선택 근거
+- [adr/ADR-003-decorator-stack-order.md](adr/ADR-003-decorator-stack-order.md) — Decorator 순서 근거
+- [adr/ADR-004-coordinator-vs-caffeine.md](adr/ADR-004-coordinator-vs-caffeine.md) — 직접 구현 vs Caffeine 비교
+- [adr/ADR-005-reactive-vs-sync-coalescing.md](adr/ADR-005-reactive-vs-sync-coalescing.md) — Reactive 적응 (Phase 6)

--- a/docs/INCIDENT.md
+++ b/docs/INCIDENT.md
@@ -1,0 +1,250 @@
+# INCIDENT — Distributed Login Lockout via Concurrent Session Refresh
+
+> **Real production incident.** 회사명 / 외부 SaaS platform 명 / 정확한 시각·수치는 NDA 보호 위해 익명화. 패턴 / timeline 구조 / 측정 방법론은 실제 그대로.
+>
+> 이 문서는 [STORY.md](STORY.md) 의 Act 2 (The Incident) 의 상세 부록. STORY 가 narrative 라면 이 문서는 **forensic timeline + customer 영향**.
+
+---
+
+## TL;DR
+
+```
+WHO       Customer A (영등포 외식 프랜차이즈 가맹점 owner)
+WHAT      Batch reply 기능 사용 중 외부 SaaS 계정 1시간 lock
+WHY       Per-user 직렬화 부재 → 80초 안에 10개 IP 로 동일 user 로그인
+          → 외부 시스템이 distributed brute-force 로 감지
+SCOPE     24h 동안 5명 customer 동일 패턴
+IMPACT    평균 lock 47분 / CS 통화 14분 / 신뢰 손상
+```
+
+---
+
+## Customer Persona — Customer A
+
+> 익명화된 합성 페르소나. 실 customer 의 demographic 만 일반화.
+
+**역할**: 외식 프랜차이즈 가맹점 owner (영등포)
+**규모**: 일평균 신규 리뷰 50건
+**사용 패턴**: 매일 일과 끝 (22:00~24:00) 에 답글 일괄 작성
+**우리 SaaS 의존도**: batch reply 가 본인의 핵심 도구 — 답글 30분 → 5분 단축
+**기술 친숙도**: 일반 사용자 (관리자 메뉴는 대시보드까지만)
+
+이 페르소나의 의미:
+- batch 기능에 가장 의존적인 사용자 segment
+- batch 가 안 되면 즉시 매출 영향 (다음날 아침 review 답변 누락 → 잠재 customer 이탈)
+- CS 문의 시 "내가 해킹당했나?" 부터 의심 (휴대폰 알림 5통 받기 때문)
+
+---
+
+## Detailed Timeline (KST)
+
+> 분 단위 정밀도. 실 incident 시각은 익명화 (시간대만 보존).
+
+### 22:42:13 — Trigger
+
+Customer A 가 cmong-admin 의 **Batch Reply** UI 에서 "전체 답변" 버튼 클릭.
+- 대상 리뷰: **20개**
+- 발사 패턴: UI 가 `setTimeout(req, getRandomNumberInRange(1000, 3000))` 으로 1~3초 간격 발사
+- 총 발사 소요: 67초
+
+### 22:42:18 — First ensureSession
+
+scraper-js 가 첫 번째 reply 요청 처리:
+```
+[NaverService] ensureSession user=user-X  (1번째)
+  cache.get(user-X) → MISS (TTL 만료)
+  externalLogin(user-X)
+    proxy.allocate(user-X) → IP 1.2.3.4 (proxy A)
+    naverLogin via Playwright
+    cookies received
+  cache.set(user-X, cookies)
+  return cookies
+```
+
+소요: 약 3 초 (Playwright + 외부 로그인). 이 동안 다음 요청들이 도착.
+
+### 22:42:21 — Second concurrent ensureSession
+
+```
+[NaverService] ensureSession user=user-X  (2번째 — 1번째 진행 중!)
+  cache.get(user-X) → MISS (1번째가 아직 cache.set 안 함)
+  externalLogin(user-X)
+    proxy.allocate(user-X) → IP 5.6.7.8 (proxy B)  ★ 다른 IP!
+```
+
+→ 1번째와 동시 진행. proxy 풀의 user lock 이 깜박이는 마이크로 윈도우 동안 새 IP 할당.
+
+### 22:42:24 ~ 22:43:35 — Cascade
+
+```
+3번째 ensureSession → IP 9.10.11.12   (proxy C)
+4번째               → IP 13.14.15.16  (proxy D)
+5번째               → IP 17.18.19.20  (proxy E)
+6번째               → IP 21.22.23.24  (proxy F)
+7번째               → IP 25.26.27.28  (proxy G)
+8번째               → IP 29.30.31.32  (proxy H)
+9번째               → IP 33.34.35.36  (proxy I)
+10번째              → IP 37.38.39.40  (proxy J)
+... (이후는 일부 cache hit, 다른 IP 도 일부 재사용)
+```
+
+**80초 윈도우 안에 unique IP 10개 → 같은 user-X 로 외부 시스템 로그인 시도.**
+
+### 22:43:43 — Detection
+
+외부 시스템의 보안 로직 발동:
+- "user-X 가 80초 안에 10개 IP 로 로그인 시도"
+- 알고리즘: distributed login attempt / credential stuffing 판단
+- → **user-X 계정에 보호조치 발동 (1시간 lock)**
+
+### 22:43:44 — Our system receives protect-setting page
+
+```
+[NaverService] readyContextPageWithRetry
+  goto smartplace.naver.com
+  → 응답: "보호조치 로그인" 페이지 (✗ 이전엔 본 적 없는 페이지)
+  → throw NaverProtectSettingException
+  → 11번째~20번째 reply 요청들도 모두 동일 페이지 받고 실패
+```
+
+우리 시스템이 처음 본 응답 → exception classification 보강 필요 (별도 issue).
+
+### 22:43:50 ~ 22:43:55 — Mail bombs
+
+외부 시스템이 user-X 의 등록된 휴대폰 + 이메일에:
+- "새로운 환경에서 로그인이 감지되었습니다" 알림 **5통** (5개 IP 가 외부에서 보안 임계값 초과한 것)
+
+Customer A 휴대폰에 22:43:50 부터 1초 간격으로 알림 5번.
+
+### 22:48:00 — Customer realizes
+
+Customer A 가 batch 결과 확인 → 모든 답글 실패 표시 → "내가 해킹당했나?" 의심.
+- 휴대폰 알림 5통 → 외부 SaaS 직접 로그인 시도 (lock 됐는지 확인)
+- → 로그인 실패. "보호조치" 페이지.
+- → CS 문의 시작.
+
+### 22:55:00 — CS call
+
+Customer Support 팀이 인지:
+- "Customer A 의 외부 SaaS 계정이 lock 됐습니다."
+- 1차 가이드: 외부 SaaS 직접 비밀번호 변경 → 보호조치 해제 안내
+- 통화 시간: **17 분**
+
+Customer A: 답글 작성 못 한 채 일과 종료. 다음 날 아침 답글 수동 처리.
+
+### 23:43 — Auto-unlock
+
+외부 시스템의 1시간 자동 lock 만료. Customer A 가 다시 우리 SaaS 사용 가능. 단, 본인은 이를 즉시 인지 못 함 (이미 일과 종료).
+
+---
+
+## Scope of Impact (24h Monitoring)
+
+이 incident 가 단발이 아니었다. RCA 후 24h 모니터링 결과:
+
+```
+2026-04-22 22:42 ~ 2026-04-23 22:42 (24h)
+
+Customer 영향: 5명 (B, C, D, E, F + Customer A)
+공통 패턴:
+  - 모두 batch reply 또는 batch 광고 보고서 등록 사용
+  - 평균 동시 요청: 15~25개
+  - 평균 다른 IP 할당: 7~12개
+  - 평균 lock 시간: 47분 (auto-unlock 또는 직접 비밀번호 변경)
+  - CS 통화: 평균 14분/건
+```
+
+CS 팀 신호:
+> "최근 batch reply 후 외부 SaaS 차단된다는 문의가 평소 대비 3배 증가"
+
+→ Engineering 팀 escalation. RCA 시작.
+
+---
+
+## Root Cause Analysis
+
+### Code Path
+
+문제의 함수 (의사코드 — 실 코드 아님, 패턴만 동일):
+
+```typescript
+async ensureSession(userId: string): Promise<Session> {
+  const cached = await cache.get(userId);
+  if (cached && validate(cached)) return cached;
+
+  // ★ 동시 호출 N 개가 모두 여기 도달
+  const newSession = await externalLogin(userId);
+  await cache.set(userId, newSession);
+  return newSession;
+}
+```
+
+### Observable Behavior
+
+1. **Trigger condition**: 동일 userId 에 대한 동시 호출 N (≥ 2)
+2. **First step**: 모두 `cache.get(userId)` 호출 → **모두 MISS** (cache 에 아직 결과 박힘)
+3. **Second step**: 모두 `externalLogin(userId)` 호출 → **N 개 외부 로그인**
+4. **Side effect**: 각자 다른 proxy IP 할당 (proxy 풀의 user lock 이 마이크로 윈도우 동안 깜박)
+5. **External perception**: 외부 시스템이 N 개 IP 로부터 동일 user 로그인 시도 감지
+
+### Why Not Caught Earlier
+
+- **단위 테스트 부재**: 동시 호출 시나리오 테스트 안 됨
+- **부하 테스트 부재**: batch UI 의 동시 패턴이 실 부하로 측정 안 됨
+- **Telemetry 부재**: proxy IP 할당 로그를 alerting 으로 연결 안 함
+- **외부 시스템 보안 정책 미문서화**: 어떤 패턴이 brute-force 로 감지되는지 우리 팀 모름
+- **Code review 의 한계**: ensureSession 가 작성될 때 batch UI 가 없었음. 추후 batch 추가 시 ensureSession 의 동시 호출 가정 재검토 안 됨
+
+→ 이 5가지 모두 [STORY.md](STORY.md) Act 7 (Lesson) 의 "다시 하면 다르게 할 것" 에 정리됨.
+
+---
+
+## Solution Trade-offs
+
+4가지 대안 검토 → Single-Flight 채택. 상세는 [STORY.md](STORY.md) Act 4 + [adr/ADR-001-port-adapter-pattern.md](adr/ADR-001-port-adapter-pattern.md).
+
+---
+
+## Verification Plan
+
+이 incident 의 Before/After 를 portfolio repo 에서 재현 가능하게 측정:
+
+| Phase | 측정 대상 | 방법 |
+|---|---|---|
+| 2 | MVC + thread pool 통점 | k6 100 동시 → Tomcat busy% / 외부 호출 수 |
+| 3 | Multi-instance coalesce | 2 인스턴스 + Redis SETNX → cross-instance 외부 호출 1번 검증 |
+| 6 | WebFlux + connection 통점 | k6 100 동시 → WebClient connection / Mono coalesce 검증 |
+
+→ [BENCHMARK.md](BENCHMARK.md) 에 결과 정리.
+
+---
+
+## NDA / Anonymization Notes
+
+이 문서가 노출하지 않는 것:
+- ❌ 실 회사명, 서비스명
+- ❌ 실 외부 SaaS platform 명
+- ❌ 실 customer 식별 정보
+- ❌ 실 시각 (날짜는 시간대만)
+- ❌ 실 매출 / customer 수치 / lock 시간 정확값
+- ❌ 내부 시스템 metric 이름 / dashboard URL
+
+이 문서가 노출하는 것:
+- ✅ 패턴 (동시 호출 + per-user 직렬화 부재)
+- ✅ Timeline 구조 (분 단위 sequence)
+- ✅ 측정 방법론
+- ✅ Trade-off 분석
+- ✅ 일반화 가능한 lessons learned
+
+면접에서 디테일 질문 시 표준 답변:
+> "비공개 NDA 라 회사명 / 외부 platform 명 / 정확 수치는 답 못 드립니다. 단 패턴 / 해법 / 일반화 통찰은 [GitHub repo] 에 정리돼있습니다."
+
+---
+
+## Related
+
+- [STORY.md](STORY.md) — narrative arc 7-act
+- [DESIGN.md](DESIGN.md) — Hexagonal + Decorator 설계
+- [BENCHMARK.md](BENCHMARK.md) — 재현 가능한 측정
+- [adr/ADR-001-port-adapter-pattern.md](adr/ADR-001-port-adapter-pattern.md) — Port/Adapter 채택 근거
+- [GitHub Issues](https://github.com/PreAgile/single-flight-coordinator-lab/issues) — Phase 1~6 진행

--- a/docs/INTERVIEW.md
+++ b/docs/INTERVIEW.md
@@ -1,0 +1,266 @@
+# INTERVIEW — Talk Track for This Project
+
+> 면접 답변 스크립트. STAR (Situation / Task / Action / Result) 프레임워크.
+> 1분 / 5분 / 딥다이브 3 단계. 자주 받을 꼬리질문 7개에 대한 답변까지.
+
+---
+
+## Pre-flight Checklist — 면접 직전 체크
+
+면접 30분 전 자가 점검:
+
+- [ ] [STORY.md](STORY.md) 의 7-act 흐름이 머릿속에 있는가
+- [ ] 핵심 측정값 4개를 외우고 있는가:
+  - 외부 호출 동시 20요청 시 20 → 1
+  - 다른 IP 할당 80초 윈도우 10 → 1
+  - P99 850ms → 32ms (예상치)
+  - 24h 동안 lock incident 5건 → 0건
+- [ ] 대안 4개의 trade-off 를 화이트보드에 그릴 수 있는가
+- [ ] 5 layer Decorator 의 순서 이유를 즉답할 수 있는가
+- [ ] [GitHub repo URL](https://github.com/PreAgile/single-flight-coordinator-lab) 알고 있는가
+
+---
+
+## 1-Minute Version
+
+### 자기소개에서 (프로젝트 한 줄)
+
+> "B2B SaaS 외부 API 연동 시스템에서 동시 요청이 외부 시스템에 distributed login 으로 감지되어 보안 차단 걸리는 incident 를 겪었습니다. SingleFlight 패턴을 Hexagonal + Decorator 로 도입해서 풀었고, 그 패턴을 Java / Spring MVC / WebFlux 로 재구현하면서 각 paradigm 의 thundering herd 표출 차이를 측정값으로 비교한 portfolio piece 입니다. GitHub 에 올라가있고, 6 Phase roadmap 으로 진행 중입니다."
+
+→ 약 50초. **Hook + 패턴 + 비교 어필 + 진행 시그널** 4 요소.
+
+---
+
+## 5-Minute Version (STAR)
+
+### Situation (1분) — 상황
+
+> "**B2B SaaS 외부 API 연동 시스템**에서, 한 customer 가 batch reply 기능 사용 중 외부 시스템의 보안 차단을 트리거하는 incident 가 발생했습니다.
+>
+> 구체적으로는 같은 user 의 동시 요청 20개가 1~3초 간격으로 우리 시스템에 도착했고, 80초 안에 10개 다른 proxy IP 로 외부 시스템에 로그인 시도가 감지되어 외부 시스템이 distributed brute-force 로 판단, 그 customer 의 계정을 1시간 lock 시켰습니다.
+>
+> 24시간 모니터링 결과 5명의 customer 에서 동일 패턴이 발생했고, customer 평균 lock 47분 + CS 통화 14분/건 + 신뢰 손상 + 향후 외부 시스템이 우리 IP 풀을 blacklist 할 위험까지 사업 영향이 누적되는 상황이었습니다."
+
+키 포인트:
+- 구체적 수치 (80초 / 10 IP / 5명 / 47분 / 14분)
+- 사업 영향 명시
+- "내가 발견했다" 가 아니라 incident 자체를 객관적으로
+
+### Task (30초) — 책임
+
+> "팀에서 제가 이 incident 의 RCA 와 architectural 해법 설계를 담당했습니다. 책임 범위는:
+> 1. Root cause 식별
+> 2. 같은 패턴 재발 방지 설계
+> 3. 미래 multi-instance 환경 확장 가능성까지 고려한 아키텍처
+> 4. Customer 영향 측정 및 비즈니스 임팩트 정량화"
+
+키 포인트: **본인 책임 명확화**. "팀이 했어요" 가 아니라 "내가 이걸 담당".
+
+### Action (2.5분) — 무엇을 했나
+
+> "Single-Flight Coordinator 패턴을 Hexagonal Architecture (Port/Adapter) + Decorator stack 으로 분리해서 도입했습니다.
+>
+> **Hexagonal 채택 이유**: 단일 인스턴스 in-process Map 으로 시작하지만, 미래에 Redis 기반 multi-instance 확장 시 NaverService 같은 도메인 코드를 안 건드리도록 backend 만 swap 가능하게 해두려고 했습니다. SingleFlightCoordinator 라는 인터페이스 (Port) 가 그 추상화입니다.
+>
+> **Decorator 4개 분리 이유**: 운영 안전망을 SOLID 원칙으로 분리했습니다.
+> - Telemetry — 로그/메트릭/waiter count (outermost)
+> - Heartbeat — 60초+ 진행 중 entry 조기 감지
+> - Capacity — 30+ waiter 거부 (UI spam 보호)
+> - Deadline — 180초 wall-clock 타임아웃 (외부 hang 강제 종료)
+>
+> 각자 단위 테스트 가능하고, env 토글로 끄고 켤 수 있습니다.
+>
+> **대안 검토**: 단순 mutex (over-locking), per-user lock (외부 호출 N번 여전), Redis 분산 lock (latency overhead + 모든 호출 SPOF), Caffeine.AsyncCache (cache 외 use case 못 다룸) 모두 검토했고 ADR-001~004 에 trade-off 정리돼있습니다."
+
+키 포인트:
+- 구체적 architectural 선택 + 이유
+- 대안 비교 명시
+- 본인이 쓴 ADR 인용 (자료 어필)
+
+### Result (1분) — 결과
+
+> "**기술 임팩트**: 외부 호출이 동시 20요청 시 20번 → 1번으로 감소, 다른 IP 할당이 80초 윈도우에서 10개 → 1개, P99 latency 850ms → 32ms.
+>
+> **비즈니스 임팩트**: 24시간 동안 발생하던 보안 차단 incident 5건이 0건으로 완전 차단됐습니다. CS 비용 + customer churn 위험 합산 연간 약 N원 손실 회피로 추정했고, 정성적으로는 외부 시스템의 IP 풀 blacklist 위험을 사전에 차단했습니다.
+>
+> **Portfolio 측면**: 이 패턴을 Java / Spring MVC / WebFlux 로 재구현해서 paradigm 별 thundering herd 표출 차이를 비교하고 있습니다. 진행 중이고 [GitHub repo URL] 에서 확인 가능합니다."
+
+키 포인트:
+- 정량 + 정성
+- "여기서 멈추지 않고 portfolio 까지" 시그널
+- repo 링크 제공
+
+---
+
+## Deep Dive — 자주 받는 꼬리질문 7개
+
+### Q1. "왜 Caffeine.AsyncCache 안 썼나요?"
+
+(Caffeine 의 `AsyncLoadingCache` 는 내장 coalesce 가 있음)
+
+**답변**:
+> "ADR-004 에 정리돼있는데, Caffeine.AsyncCache 는 cache 라는 가정 하에 동작합니다. 즉:
+> 1. 결과를 보관하는 게 목적 (cache 의 본질)
+> 2. TTL 기반 만료
+>
+> 우리 use case 인 `ensureSession()` 은 cache 가 아니라 **외부 자원 할당**입니다. 결과 보관은 별도 cache 가 이미 함. 우리가 필요한 건 **'동시 호출을 1번으로 합치는 것 자체'** 였고, deadline / capacity / telemetry 같은 운영 안전망까지 통합하기 위해 별도 추상화가 필요했습니다.
+>
+> 또한 Caffeine 에 묶이면 미래 Redis 기반 multi-instance 로 갈 때 추상화 swap 이 어려워집니다. Port/Adapter 로 분리해두면 backend 만 갈아끼우면 됩니다."
+
+### Q2. "Decorator 순서가 의미 있나요?"
+
+**답변**:
+> "ADR-003 에 정리돼있습니다. 순서가 의미 있습니다.
+>
+> 안쪽부터: Base → Deadline → Capacity → Heartbeat → Telemetry (outermost).
+>
+> **Telemetry 가 outermost 인 이유**: Deadline decorator 가 throw 하는 `SingleFlightDeadlineException` 을 분류해서 status=deadline 으로 메트릭 찍어야 하기 때문입니다. Telemetry 가 안쪽에 있으면 deadline exception 이 아니라 hang 만 보입니다.
+>
+> **Capacity 가 Deadline 위인 이유**: capacity 검사는 즉시 reject 인 반면 deadline 은 진행 중인 op 의 timeout. 즉 capacity 가 먼저 check → 통과면 deadline 의 timer 시작.
+>
+> 순서 바뀌면 분류 / observability 가 부정확해집니다."
+
+### Q3. "Multi-instance 환경에선?"
+
+**답변**:
+> "ADR-002 에 정리돼있습니다. 단일 인스턴스 in-process Map 으로 시작했고, 멀티 인스턴스로 갈 때 Redis SETNX + Lua 해제 + pub/sub 결과 broadcast 로 확장합니다.
+>
+> 처음부터 Redis 안 한 이유:
+> 1. 운영 단순성 (Redis 의존 추가는 SPOF 추가)
+> 2. 단일 인스턴스 시점에는 latency overhead 3-10ms 가 비용 대비 가치 없음
+> 3. Redis 장애 시 fallback 정책이 별도 설계 필요
+>
+> Multi-instance 로 갈 때 **Coordinator 만 swap**, NaverService 코드는 0 수정. 이게 Hexagonal Port/Adapter 의 가치입니다."
+
+### Q4. "MVC vs WebFlux 어느 게 더 좋나요?"
+
+**답변**:
+> "더 좋다 가 아닌 다른 trade-off 입니다.
+>
+> **MVC**: Tomcat thread pool 보호가 핵심. Thread-per-request 라 동시 N 요청이 N thread 점유. SingleFlight 도입 시 N-1 thread 즉시 free.
+>
+> **WebFlux**: Connection pool 보호가 핵심. Event loop 는 안 막히지만 WebClient connection pool 폭증. SingleFlight 도입 시 connection 1번만 유지.
+>
+> 같은 thundering herd 인데 표출되는 자원이 다릅니다. 트래픽 패턴 / downstream 특성 / 팀 역량에 따라 결정. 토스 같이 reactive 헤비한 곳은 WebFlux, 일반 CRUD 헤비한 곳은 MVC.
+>
+> Portfolio 의 cross-paradigm 챕터에서 두 모델의 측정값을 같이 보여줍니다."
+
+### Q5. "Java 21 Virtual Threads 면 다 해결 아닌가요?"
+
+**답변**:
+> "Virtual Threads 는 thread 비용을 cheap 하게 만들지만 **downstream 자원은 비싸다** 는 게 그대로입니다.
+>
+> 즉:
+> - VT 환경에서도 1000 동시 요청 → 1000 outbound connection
+> - 외부 시스템은 여전히 distributed login 으로 감지 가능
+> - 외부 rate limit / cost 도 여전
+>
+> SingleFlight 는 'thread' 보호가 본질이 아니라 'downstream' 보호가 본질이라 VT 와 직교적입니다.
+>
+> v1.1 의 Phase 7 에서 VT demo 추가해서 시연 예정입니다."
+
+### Q6. "Coroutines (Kotlin) 와 비교는?"
+
+**답변**:
+> "같은 패턴, 다른 idiom.
+>
+> Kotlin 의 경우:
+> - `Mutex.withLock { ... }` + `Deferred<T>` 로 coalesce 표현
+> - `ConcurrentHashMap.computeIfAbsent` + `CompletableFuture` 와 본질 동일
+> - 다만 코루틴 컨텍스트에서 자연스럽게 통합
+>
+> 토스 / 우아한형제들 / 당근 같이 Kotlin + Coroutines 헤비한 곳에선 이 idiom 이 더 익숙합니다. v1.1 Phase 8 에서 demo 추가 예정입니다.
+>
+> 핵심 통찰: paradigm 이 달라도 본질 (per-key coalesce) 은 같고 idiom 만 다릅니다. THESIS 의 L4-L5 단계입니다."
+
+### Q7. "Deadline 안에 Heartbeat 도 있는데 중복 아닌가요?"
+
+**답변**:
+> "역할이 다릅니다.
+>
+> **Deadline (180초)**: hard wall-clock 타임아웃. 도달 시 owner + 모든 waiter 강제 reject. **사후 차단**.
+>
+> **Heartbeat (60초)**: 진행 중 entry 의 age 가 60초+ 되면 `long_running` warn 로그 + alert. **사전 감지**.
+>
+> 즉 60~180초 구간에 heartbeat 가 운영자에게 'stuck 가능성' 알림 → 운영자가 force release 또는 조사 → deadline 도달 전에 수동 개입 가능. Deadline 만 있으면 운영자가 180초 기다리고 사후에야 발견.
+>
+> 또한 두 메커니즘은 다른 행동:
+> - Deadline = 강제 reject (사용자에게 에러)
+> - Heartbeat = 관찰만 (사용자 영향 없음)
+>
+> 같이 있어야 운영 안전망이 완성됩니다."
+
+---
+
+## 추가 꼬리질문 — 비즈니스 측면
+
+### Q. "이 incident 의 비즈니스 임팩트를 어떻게 정량화했나요?"
+
+**답변**:
+> "[BENCHMARK.md](BENCHMARK.md) 의 비즈니스 임팩트 framework 에 정리했는데:
+>
+> 1. **CS 비용**: lock incident 평균 처리 시간 14분 × CS 시급 × 월 incident 추정 → 월 N1 원
+> 2. **Customer churn 위험**: lock 후 24h 미접속 비율 P% → 월 잠재 churn M명 × LTV → 월 N2 원
+> 3. **정성 위험**: 외부 시스템 IP 풀 blacklist 가능성, 평판 손상, ToS 위반 의심
+>
+> 합산 연간 회피 가치 N1+N2 × 12 ≈ N 원 추정.
+>
+> 정확한 N 값은 NDA 영역이지만, **이렇게 정량화하는 사고 자체** 가 시니어 어필 포인트라고 봅니다."
+
+### Q. "이 패턴이 다른 도메인에도 적용 가능한가요?"
+
+**답변**:
+> "Single-Flight 는 thundering herd 의 표준 해법입니다. 적용 가능 도메인:
+>
+> 1. Cache stampede 방지 (Caffeine 도 이걸 함)
+> 2. 외부 API rate limit 보호
+> 3. 비싼 계산의 동시 실행 방지 (deduplicated computation)
+> 4. 분산 시스템의 leader election layer
+> 5. DB connection pool 의 connection 획득 race
+> 6. Auth token refresh 합치기
+>
+> 본질은 '동일 key 의 동시 호출을 1번으로 합치는' 보편 패턴이고, Hexagonal + Decorator 구조라 어느 domain 에든 swap 가능합니다."
+
+---
+
+## 안티 패턴 — 면접에서 피할 답변
+
+### ❌ "그냥 SingleFlight 패턴 썼어요"
+→ 시니어가 아닌 신호. **왜 그게 필요했고, 어떤 대안과 비교했는지** 말해야.
+
+### ❌ "P99 가 850ms 에서 32ms 로 빨라졌어요"
+→ 비즈니스 임팩트 누락. **외부 호출 N→1 + customer lock 차단 + 사업 위험 회피** 까지.
+
+### ❌ "Caffeine 보다 직접 짠 게 더 나아요"
+→ NIH 시그널. **Caffeine 검토했고, 우리 use case (cache 아닌 외부 자원 할당) 에 맞는 대안 선택** 으로.
+
+### ❌ "WebFlux 가 Spring MVC 보다 우월합니다"
+→ 단편적. **trade-off, 표출되는 자원 차이** 로.
+
+### ❌ "AI 로 짰어요"
+→ 도구 자랑. **본인이 architectural 결정 + 비즈니스 사고 했고, AI 는 boilerplate 작성 보조** 로.
+
+---
+
+## 면접 후 — Self-debrief 체크리스트
+
+면접 끝난 후 자가 점검:
+
+- [ ] STAR 4 단계 다 말했나
+- [ ] 측정값 4개 (외부 호출 / IP / P99 / 차단) 다 말했나
+- [ ] 대안 4개 검토 trade-off 말했나
+- [ ] ADR cite 했나 (있는 줄 알게 했나)
+- [ ] GitHub repo 링크 제공했나
+- [ ] 비즈니스 임팩트 (정량 + 정성) 말했나
+- [ ] 일반화 (다른 도메인 적용 가능성) 언급했나
+- [ ] AI / 도구 의존 어필 안 했나
+
+---
+
+## Related
+
+- [STORY.md](STORY.md) — 7-act narrative arc
+- [INCIDENT.md](INCIDENT.md) — 익명화된 customer story
+- [BENCHMARK.md](BENCHMARK.md) — 비즈니스 임팩트 framework
+- [adr/](adr/) — 5 ADR (cite 가능)
+- [THESIS.md](THESIS.md) — portfolio 진화 thesis (L0 → L5)

--- a/docs/INTERVIEW.md
+++ b/docs/INTERVIEW.md
@@ -10,11 +10,12 @@
 면접 30분 전 자가 점검:
 
 - [ ] [STORY.md](STORY.md) 의 7-act 흐름이 머릿속에 있는가
-- [ ] 핵심 측정값 4개를 외우고 있는가:
-  - 외부 호출 동시 20요청 시 20 → 1
-  - 다른 IP 할당 80초 윈도우 10 → 1
-  - P99 850ms → 32ms (예상치)
-  - 24h 동안 lock incident 5건 → 0건
+- [ ] 핵심 측정값 4개를 외우고 있는가 (라벨 분리):
+  - 📂 **운영 추정**: 외부 호출 동시 20요청 시 20 → 1
+  - 📂 **운영 추정**: 다른 IP 할당 80초 윈도우 10 → 1
+  - 📂 **운영 추정**: 24h 동안 lock incident 5건 → 0건
+  - 🎯 **합성 벤치 가설** (S2 cache+SF): P99 850ms → ~5ms (Phase 2 측정 예정)
+  - 📊 **실측**: TBD (Phase 2 완료 후)
 - [ ] 대안 4개의 trade-off 를 화이트보드에 그릴 수 있는가
 - [ ] 5 layer Decorator 의 순서 이유를 즉답할 수 있는가
 - [ ] [GitHub repo URL](https://github.com/PreAgile/single-flight-coordinator-lab) 알고 있는가
@@ -25,9 +26,11 @@
 
 ### 자기소개에서 (프로젝트 한 줄)
 
-> "B2B SaaS 외부 API 연동 시스템에서 동시 요청이 외부 시스템에 distributed login 으로 감지되어 보안 차단 걸리는 incident 를 겪었습니다. SingleFlight 패턴을 Hexagonal + Decorator 로 도입해서 풀었고, 그 패턴을 Java / Spring MVC / WebFlux 로 재구현하면서 각 paradigm 의 thundering herd 표출 차이를 측정값으로 비교한 portfolio piece 입니다. GitHub 에 올라가있고, 6 Phase roadmap 으로 진행 중입니다."
+> "B2B SaaS 외부 API 연동 시스템에서 동시 요청이 외부 시스템에 distributed login 으로 감지되어 보안 차단 걸리는 incident 를 겪었습니다. 그 패턴을 Single-Flight Coordinator 로 풀었던 경험을, Hexagonal + Decorator 구조로 정리하면서 Java / Spring MVC / WebFlux 의 paradigm 별 thundering herd 표출 차이를 재현 가능한 lab 으로 만드는 중입니다. GitHub 에 올라가있고, 6 Phase roadmap 중 진행 중입니다 (현재 Phase X — 라벨 분리: 📂 운영 추정 / 📊 합성 벤치 측정 예정)."
 
-→ 약 50초. **Hook + 패턴 + 비교 어필 + 진행 시그널** 4 요소.
+→ 약 60초. **Hook + 패턴 + 진행 시그널 + 검증 정직성** 4 요소.
+
+> ⚠️ **표현 주의**: "도입해서 풀었고 측정값으로 비교했습니다" → 운영에선 풀었지만, **이 repo 의 합성 벤치 측정은 Phase 진행 중**. 라벨 분리하여 정직하게.
 
 ---
 
@@ -79,16 +82,19 @@
 
 ### Result (1분) — 결과
 
-> "**기술 임팩트**: 외부 호출이 동시 20요청 시 20번 → 1번으로 감소, 다른 IP 할당이 80초 윈도우에서 10개 → 1개, P99 latency 850ms → 32ms.
+> "**운영 환경 임팩트** 📂 (익명화 추정): 외부 호출이 동시 20요청 시 20번 → 1번, 다른 IP 할당이 80초 윈도우에서 10개 → 1개, 24시간 동안 발생하던 보안 차단 incident 5건이 0건으로.
 >
-> **비즈니스 임팩트**: 24시간 동안 발생하던 보안 차단 incident 5건이 0건으로 완전 차단됐습니다. CS 비용 + customer churn 위험 합산 연간 약 N원 손실 회피로 추정했고, 정성적으로는 외부 시스템의 IP 풀 blacklist 위험을 사전에 차단했습니다.
+> **합성 벤치 가설** 🎯 (Phase 2~6 측정 예정): cache+SF S2 시나리오에서 P99 850ms → ~5ms, single-flight 만의 효과 (S3) 는 외부 호출 ~120 → ~1 (60s 부하 기준). **현재 라벨은 가설이고, Phase 측정 시 실측 ↔ 가설 비교 표로 갱신** 됩니다.
 >
-> **Portfolio 측면**: 이 패턴을 Java / Spring MVC / WebFlux 로 재구현해서 paradigm 별 thundering herd 표출 차이를 비교하고 있습니다. 진행 중이고 [GitHub repo URL] 에서 확인 가능합니다."
+> **비즈니스 임팩트** 📂: CS 비용 + customer churn 위험 합산 연간 약 N원 손실 회피로 추정 (정확 N 값은 NDA, 사고 방식은 [BENCHMARK.md] 의 4 차원 framework 에). 정성적으로는 외부 시스템의 IP 풀 blacklist 위험을 사전에 차단.
+>
+> **Portfolio 측면**: 이 패턴을 Java / Spring MVC / WebFlux 로 재구현하면서 paradigm 별 thundering herd 표출 차이를 측정 시나리오 (S1 burst / S2 cache+SF / S3 pure SF) 로 분리해 비교 중입니다. 진행 중이고 [GitHub repo URL] 에서 확인 가능합니다."
 
 키 포인트:
-- 정량 + 정성
-- "여기서 멈추지 않고 portfolio 까지" 시그널
+- **라벨 분리** (📂 운영 추정 / 🎯 합성 벤치 가설 / 📊 측정값)
+- 정직성 — "측정 예정" 명시
 - repo 링크 제공
+- 비즈니스 임팩트 framework cite 가능 시그널
 
 ---
 

--- a/docs/STORY.md
+++ b/docs/STORY.md
@@ -1,0 +1,421 @@
+# STORY — How We Stopped Distributed Login from Locking Our Customers Out
+
+> 이 문서는 portfolio 의 **centerpiece narrative** 입니다. 15분 깊은 읽기용.
+> 회사명 / 외부 SaaS platform 명 / 정확한 시각·수치는 NDA 보호 위해 익명화.
+> 패턴 / timeline / 측정 방법론은 실제 그대로.
+
+---
+
+## Act 1 — Hook
+
+> **2026 년 봄 어느 평일 밤.**
+>
+> 한 customer 가 자기 매장 답글 20 개를 자동 등록하는 batch 기능을 실행했다.
+> 80 초 후, 그 customer 의 외부 SaaS 계정이 1 시간 lock 됐다.
+> 외부 시스템은 우리 서버를 *"distributed brute-force login attempt"* 로 감지했다.
+>
+> 이 글은 그 incident 의 **RCA**, **architectural 해법**,
+> 그리고 그 과정에서 발견한 **4 가지 동시성 paradigm 의 본질** 에 대한 기록이다.
+
+---
+
+## Act 2 — The Incident
+
+### Customer A — 영등포의 한 매장 owner
+
+Customer A 는 외식 프랜차이즈 가맹점 owner. 매일 평균 50 건의 신규 리뷰를 받고, 각자 답변을 달아주는 게 본인 업무. 우리 SaaS 의 **batch reply** 기능을 쓰면 답글 작성 시간이 30 분 → 5 분으로 줄어든다. 본인의 일과 끝의 핵심 도구.
+
+### Timeline (KST, 분 단위)
+
+```
+T+0    Customer A 가 batch reply 기능 실행 (20개 reply)
+       UI 가 1~3초 간격으로 요청 발사 (총 67초 소요)
+
+T+10s  scraper-js 의 ensureSession() 가 Customer A 의 user-X 에 대해 1번째 호출
+       → 외부 세션 cache miss → 새 로그인 → proxy A 로 IP 1.2.3.4 할당
+
+T+12s  2번째 reply 요청 도착
+       → ensureSession() 동시 호출 (1번째 아직 진행 중)
+       → cache 에 1번째 결과 아직 안 박힘 → 또 새 로그인
+       → proxy B 로 IP 5.6.7.8 할당
+
+T+15s  3번째 → IP 9.10.11.12
+T+22s  4번째 → IP ...
+...
+T+82s  10번째 다른 IP 할당. (이미 외부 시스템에 boundary signal)
+
+T+90s  외부 시스템 보안 로직 발동:
+       "user-X 가 80초 안에 10개 IP 로 로그인 시도"
+       → distributed brute-force 감지
+       → user-X 계정에 보호조치 발동 (1시간 lock)
+
+T+91s  우리 scraper-js 가 외부 시스템에서 "보호조치 로그인" 페이지 응답 수신
+       → 우리 시스템도 처음 본 페이지 (이전엔 정상 로그인 페이지만)
+
+T+95s  Customer A 의 휴대폰에 외부 시스템 발신 알림:
+       "새로운 환경에서 로그인이 감지되었습니다" × 5통
+
+T+8min Customer A 가 외부 SaaS 직접 로그인 시도 → 차단됨 → CS 문의
+```
+
+### Customer 영향
+
+- 그날 batch reply **불가**
+- 1 시간 동안 답글 **수동 작성**으로 대체 (작업 시간 30분 → 30분 + 1시간 대기)
+- CS 통화 **17 분**
+- 휴대폰 알림 5 통 → 본인이 해킹당한 줄 알고 비밀번호 변경
+- 변경된 비밀번호로 다시 우리 SaaS 에 로그인 → 다음 날 batch 시도까지 **24h+ 신뢰 손상**
+
+### 24 h 동안 같은 패턴
+
+이게 단발이 아니었다. 24 h 모니터링:
+- **5 명의 customer** 가 동일 차단 발생
+- 평균 lock 시간 **47 분** (외부 시스템의 자동 해제 + CS 통화 후 외부 시스템에 정상 로그인)
+- 평균 CS 통화 시간 **14 분/건**
+
+Customer Support 팀이 보고: "최근 batch reply 후 차단된다는 문의가 평소 대비 3 배."
+
+→ Engineering 에 escalation. **이 incident 의 RCA 가 시작.**
+
+---
+
+## Act 3 — The Investigation
+
+### 가설 1 — 외부 시스템 일시 장애?
+
+**검증**:
+- Datadog 에서 다른 customer 들의 외부 시스템 호출 metric 확인
+- 동일 시간 window 에 다른 customer 들은 **정상 응답률**
+- → **외부 시스템 자체는 멀쩡**. **우리만 이 customer 들에 대해 차단**.
+
+**기각.**
+
+### 가설 2 — Proxy 풀 문제?
+
+**검증**:
+- ISP proxy provider (Decodo) 의 헬스체크 → 정상
+- 우리 proxy 풀에서 다른 user 들은 정상 동작
+- → **Proxy 자체는 정상**. **할당 패턴이 이상**.
+
+**기각, 단 hint 발견**: "왜 같은 user 인데 80 초에 10 개 IP 가 할당되지?"
+
+### 가설 3 — 인증 정보 만료?
+
+**검증**:
+- Customer A 의 비밀번호 변경 이력: 90 일 전이 마지막
+- 외부 SaaS 의 토큰 만료 정책: 만료 시 단순 재로그인
+- → **인증 정보 만료가 원인이 아님**. 만료라면 1 번만 다시 로그인했어야 함.
+
+**기각.**
+
+### 가설 4 — 우리가 외부 시스템에 비정상 패턴 보낸 건가?
+
+**증거**:
+```
+22:42:13 ~ 22:43:35 (82초 윈도우)
+proxy log 분석:
+  - 같은 user-X 에 대한 ensureSession() 호출 20 번
+  - 할당된 unique IP 10 개 (proxy 풀 라이브러리의 user lock 깜박이는 시간 동안 새 IP 할당)
+```
+
+**핵심 발견**:
+> 같은 user 가 80 초 안에 10 개 다른 IP 로 외부 시스템에 로그인 = distributed login attempt 패턴
+
+→ 외부 시스템 입장에선 우리 = **bot net 의 분산 공격**.
+
+### Root Cause
+
+코드 추적:
+
+```typescript
+// 의사코드 (실제 코드 아님)
+async ensureSession(userId) {
+  const cached = await cache.get(userId);
+  if (cached && validate(cached)) return cached;
+
+  // ★ 여기 — 동시 N 호출이 모두 이 분기에 도달
+  const newSession = await externalLogin(userId);  // 새 proxy IP 할당
+  await cache.set(userId, newSession);
+  return newSession;
+}
+```
+
+→ **per-user 직렬화 부재.** 동시 호출이 cache lookup 모두 miss → 각자 새 외부 로그인 → 각자 다른 proxy IP.
+
+이 함수는 코드베이스 전체에서 외부 SaaS 호출의 entry point. 비즈니스 로직이 점점 복잡해지면서 설계 시 가정한 "동시 호출 거의 없을 것" 이 무너졌다. Batch 기능이 추가되면서 명시적으로 동시 호출 패턴이 발생.
+
+---
+
+## Act 4 — The Decision
+
+해법으로 4 가지 옵션 검토.
+
+### 대안 A — 단순 동기 lock
+
+```typescript
+const lock = new Mutex();
+async ensureSession(userId) {
+  await lock.acquire();
+  try {
+    /* 기존 로직 */
+  } finally {
+    lock.release();
+  }
+}
+```
+
+**Trade-off**:
+- ✅ 가장 단순, 즉시 incident 차단
+- ❌ **모든 user 가 직렬화** → user-A 가 ensureSession 도는 동안 user-B 도 대기 (over-locking)
+- ❌ Throughput 폭락
+- ❌ Customer A 1명 보호하려고 모든 customer feedback latency 증가
+
+**기각** — over-locking.
+
+### 대안 B — Per-user lock (synchronized block per userId)
+
+```typescript
+const userLocks = new Map<string, Mutex>();
+async ensureSession(userId) {
+  if (!userLocks.has(userId)) userLocks.set(userId, new Mutex());
+  await userLocks.get(userId).acquire();
+  /* ... */
+}
+```
+
+**Trade-off**:
+- ✅ 같은 user 만 직렬화
+- ❌ N waiter 가 모두 외부 호출 N 번 (대기 후 각자 호출)
+- ❌ N 번 외부 호출 자체가 thundering herd → 외부 시스템 다시 차단
+- ❌ Multi-instance 환경에선 무력 (JS 단일 process 한정)
+
+**기각** — 차단 문제 안 풀림.
+
+### 대안 C — Redis 분산 lock
+
+```typescript
+const lock = await redis.acquireLock(`session:${userId}`);
+/* ... */
+await lock.release();
+```
+
+**Trade-off**:
+- ✅ Multi-instance 커버
+- ✅ User-level 직렬화
+- ❌ 모든 호출에 latency overhead 3-10ms (Redis RTT)
+- ❌ Redis 장애 시 전체 ensureSession 막힘
+- ❌ 결과 공유 메커니즘이 별도로 필요 (lock 후에 내가 외부 호출할지, 누가 했으면 결과 가져올지)
+
+**기각, 단 P1 후보로 보존** — 멀티 인스턴스 시 다시 검토 (Phase 3 의 ADR-002 에서).
+
+### 대안 D — Single-Flight 패턴 (Go singleflight 모델) ★ 채택
+
+```typescript
+const inflight = new Map<userId, Promise<Session>>();
+async ensureSession(userId) {
+  if (inflight.has(userId)) return inflight.get(userId);  // waiter
+  const promise = externalLogin(userId).finally(() => inflight.delete(userId));
+  inflight.set(userId, promise);
+  return promise;
+}
+```
+
+**Trade-off**:
+- ✅ **Per-user 직렬화 + 결과 공유** (1 owner + N waiter)
+- ✅ 외부 호출 1 번 (대안 B 대비 N 분의 1)
+- ✅ Latency overhead 거의 0 (메모리 lookup)
+- ✅ 단일 인스턴스에서 충분, 멀티 인스턴스로 점진적 확장 가능
+- ⚠️ 단일 process 한정 → 미래에 Redis layer 필요할 수 있음
+
+**채택**. **Single-Flight + Hexagonal (multi-instance 확장 여지) + Decorator stack (운영 안전망)** 을 종합 설계.
+
+---
+
+## Act 5 — The Solution
+
+### Architecture — Hexagonal Port/Adapter + Decorator Stack
+
+```
+NaverService.ensureSession()
+        │
+        ▼
+SingleFlightCoordinator (Port)        ← 인터페이스만 의존
+        │
+        ▼
+[Telemetry Decorator]                  ← outermost: 로그 / 메트릭 / waiter count
+        │
+        ▼
+[Heartbeat Decorator]                  ← 60s+ 진행 중 entry 경고
+        │
+        ▼
+[Capacity Decorator]                   ← 30+ waiter 거부 (load shedding)
+        │
+        ▼
+[Deadline Decorator]                   ← 180s wall-clock 타임아웃
+        │
+        ▼
+InProcessSingleFlightCoordinator       ← Base: ConcurrentHashMap.computeIfAbsent
+        │
+        ▼
+ensureSessionImpl() (Playwright 영역)
+```
+
+상세 설계: [DESIGN.md](DESIGN.md)
+
+### Why Hexagonal?
+
+`SingleFlightCoordinator` 가 인터페이스라서 **backend swap 이 NaverService 코드 수정 없이 가능**:
+- 단일 인스턴스 → in-process Map
+- 멀티 인스턴스 → Redis SETNX + pub/sub (Phase 3, ADR-002)
+- (미래) MQ routing 도 추상화 합성으로
+
+### Why Decorator?
+
+운영 안전망 4개를 SOLID 원칙으로 분리:
+1. **Telemetry** — observability (로그 + 메트릭)
+2. **Heartbeat** — 60s+ stuck 조기 감지
+3. **Capacity** — UI spam 방어 (cap 초과 거부)
+4. **Deadline** — 외부 hang 강제 종료 (180s wall-clock)
+
+각자 단위 테스트 가능. Stack 순서가 의미 있음 (ADR-003 참고).
+
+### Implementation Phases
+
+| Phase | 내용 | Status |
+|---|---|---|
+| 1 | coordinator-core (Pure Java) | 🔜 |
+| 2 | mvc-demo + 측정 | 🔜 |
+| 3 | redis-adapter (multi-instance) | 🔜 |
+| 4 | TS reference + cross-language | 🔜 |
+| 6 | webflux-demo (reactive) | 🔜 |
+| 5 | polish | 🔜 |
+
+[Issues](https://github.com/PreAgile/single-flight-coordinator-lab/issues) 에서 진행 상황 추적.
+
+---
+
+## Act 6 — The Result
+
+### 기술 임팩트 (정량)
+
+> ⚠️ 아래 측정값은 실 운영 incident 의 추정값입니다. 본 repo 의 [BENCHMARK.md](BENCHMARK.md) 에서 재현 가능한 합성 부하 + Phase 2 측정으로 검증 예정.
+
+| 항목 | Before (without single-flight) | After (with single-flight) | Δ |
+|---|---|---|---|
+| 외부 호출 수 (동시 20 요청) | 20 | 1 | **20× 감소** |
+| 다른 IP 할당 (80초 윈도우) | 10 | 1 | **10× 감소** |
+| P99 latency | ~850ms | ~32ms | **26× 빠름** |
+| 외부 시스템 보안 차단 | 발생 | 0 (24h 모니터링) | **완전 차단** |
+| 영향받은 customer (24h) | 5 명 | 0 명 | **0** |
+
+### 비즈니스 임팩트 (정량 추정)
+
+```
+[Customer Support 비용]
+  - 평균 lock incident 처리 시간: 14 분
+  - 24h 동안 incident: 5건 → 월 환산: ~150건
+  - CS 시급 (시장 평균): X 원
+  - 월 CS 비용: 150 × 14분 × X원 = N1 원
+
+[Customer 이탈 위험]
+  - lock 후 24h 미접속 customer: P% (lock 직후 측정)
+  - 월간 churn 추가: P% × 150 = M 명
+  - 1 인당 평균 매출 (LTV 기반): R 원
+  - 월간 매출 손실: M × R = N2 원
+
+[합산 회피 가치]
+  연간 회피 ≈ (N1 + N2) × 12 ≈ 약 N 원
+
+[정성 위험]
+  - 외부 시스템 IP 풀 blacklist 가능성 (서비스 전면 중단 risk)
+  - 평판 손상 (외부 SaaS 가 우리 서비스 차단 발표 시)
+  - Compliance 위험 (외부 시스템 ToS 위반 의심)
+```
+
+→ **단순 기술 개선이 아니라 사업 위험 회피.** ([BENCHMARK.md](BENCHMARK.md) 의 비즈니스 임팩트 framework 참고)
+
+### Counterfactual — 안 고쳤다면
+
+- batch reply 기능 사용량 증가 추세 (월 +15% 도입률)
+- Incident 빈도도 비례 증가 → 6 개월 후 월 ~300 건 예상
+- 외부 시스템이 차단 정책 강화 시 → 차단 시간 1시간 → 24시간 가능
+- 차단 누적 → 외부 시스템에서 우리 IP 풀 blacklist → **서비스 전면 중단 시나리오**
+
+→ "고쳤으니 다행" 이 아니라 **"안 고쳤으면 회사가 위험" 이었던 부류**.
+
+---
+
+## Act 7 — The Lesson
+
+### 무엇을 배웠나
+
+**1. 외부 시스템의 보안 알고리즘은 우리에게 비기능 요구사항이다**
+
+정상적인 우리 동작이 외부에선 비정상으로 보일 수 있다. API 호출 패턴 자체가 SLA 의 일부.
+→ Engineering onboarding 에 외부 시스템의 보안 정책 문서화 추가.
+
+**2. "외부 자원 할당" 함수는 본질적으로 single-flight 가 필요**
+
+이런 함수의 특징:
+- 호출 비용이 큼 (외부 호출, 네트워크, 자원 할당)
+- 동시 호출이 동일 결과를 만들어야 함 (idempotent)
+- 부수 효과가 외부 시스템에 의미 있음
+
+→ 코드 리뷰 시 이런 함수 보이면 single-flight 패턴 검토.
+
+**3. Measurement-driven development 의 진짜 의미**
+
+"P99 좋아짐" 이 아니라 **"외부 호출 N → 1"** 처럼 비즈니스 임팩트와 직결되는 메트릭이 진짜 무기. portfolio 도 같은 원칙.
+
+**4. 동시성 paradigm 별 같은 문제의 다른 표출**
+
+이 incident 가 thundering herd 의 한 형태였고, MVC / WebFlux / Loom / Coroutines 어느 paradigm 에서도 발생. 다만 표출되는 자원이 다름 (thread / connection / VT count). 새 framework 만나도 같은 사고로 적응 가능. ([THESIS.md](THESIS.md) 의 L4-L5)
+
+### 다시 하면 다르게 할 것
+
+1. **ensureSession 을 코드 작성 시점에 single-flight 로 짰을 것** (incident 후 fix 하지 말고). 외부 자원 할당 함수의 default 패턴.
+2. **외부 시스템의 보안 정책을 문서화** 했어야 함. 어떤 호출 패턴이 brute-force 로 감지되는지.
+3. **proxy IP 할당 로그를 incident 전에 alerting** 했어야 함. 80초 10 IP 임계값. → 사전에 차단 가능했음.
+4. **Customer-impacting incident 의 회고가 늦었음**. CS 팀의 "평소 대비 3배" 신호가 더 빨리 escalation 됐어야 함.
+
+### 이 패턴이 일반화되는 곳
+
+Single-Flight 는 thundering herd 의 한 표준 해법. 적용 가능한 곳:
+
+| 도메인 | 적용 사례 |
+|---|---|
+| Cache | Cache stampede 방지 (만료 시 동시 backing store 호출) |
+| 외부 API | Rate limit 보호 (동시 동일 resource 호출 합치기) |
+| 비싼 계산 | 동일 input 의 동시 계산 합치기 (deduplicated computation) |
+| 분산 시스템 | Leader election, 분산 lock 의 single-flight layer |
+| DB | Connection pool 의 connection 획득 race |
+| Auth | Token refresh 동시 호출 합치기 |
+
+이 repo 의 패턴은 **외부 API 의 보안 차단** 맥락에서 출발했지만, 본질은 **"동일 key 의 동시 호출을 1번으로 합치는"** 보편 패턴.
+
+---
+
+## 후기 — 이 글이 의도하는 것
+
+이 STORY 는 portfolio 의 한 piece 이기 전에 **본인의 회고**입니다.
+
+배운 것:
+- 시니어급 architectural 사고가 무엇인지 (대안 4개를 비교하고 trade-off 명시)
+- 비즈니스 임팩트와 기술 임팩트를 같이 보는 사고
+- 외부 의존성의 행동을 우리 시스템 SLA 의 일부로 인식하기
+
+배운 것을 글로 정리하지 않으면 6개월 후 잊는다. 이 글이 미래의 본인에게 **"왜 이 코드를 이렇게 짰는지"** 답변이 되길.
+
+그리고 portfolio 측면에서, 이 글은 면접관에게 **"이 사람이 단순 패턴 구현 능력만이 아니라 비즈니스 사고 + 회고 능력 + 일반화 능력 가진 사람"** 이라는 시그널.
+
+---
+
+## 관련 문서
+
+- [INCIDENT.md](INCIDENT.md) — Customer A 의 인간적 narrative + 상세 timeline
+- [DESIGN.md](DESIGN.md) — Hexagonal + Decorator architecture 상세
+- [BENCHMARK.md](BENCHMARK.md) — 측정 방법론 + 비즈니스 임팩트 framework
+- [INTERVIEW.md](INTERVIEW.md) — 1분 / 5분 (STAR) / 딥다이브 답변 스크립트
+- [THESIS.md](THESIS.md) — 이 portfolio 의 진화 thesis (L0 → L5)
+- [adr/](adr/) — Architecture Decision Records 5개
+- [GitHub Issues](https://github.com/PreAgile/single-flight-coordinator-lab/issues) — 6 Phase 진행 상황

--- a/docs/STORY.md
+++ b/docs/STORY.md
@@ -380,17 +380,43 @@ ensureSessionImpl() (Playwright 영역)
 
 ## Act 6 — The Result
 
-### 기술 임팩트 (정량)
+### 측정값 라벨 — 출처 분리
 
-> ⚠️ 아래 측정값은 실 운영 incident 의 추정값입니다. 본 repo 의 [BENCHMARK.md](BENCHMARK.md) 에서 재현 가능한 합성 부하 + Phase 2 측정으로 검증 예정.
+수치마다 출처가 다름. 4 라벨로 명시:
 
-| 항목 | Before (without single-flight) | After (with single-flight) | Δ |
-|---|---|---|---|
-| 외부 호출 수 (동시 20 요청) | 20 | 1 | **20× 감소** |
-| 다른 IP 할당 (80초 윈도우) | 10 | 1 | **10× 감소** |
-| P99 latency | ~850ms | ~32ms | **26× 빠름** |
-| 외부 시스템 보안 차단 | 발생 | 0 (24h 모니터링) | **완전 차단** |
-| 영향받은 customer (24h) | 5 명 | 0 명 | **0** |
+- 📂 **Anonymized Production Estimate** — 실 운영 incident 익명화 추정
+- 🎯 **Hypothesis** — 합성 벤치 가설 / 목표치 (Phase 측정 전)
+- 📊 **Measured** — Phase 별 실측 (현재 모두 TBD)
+- 📅 **Planned** — 미래 작업 / 환경
+
+### 기술 임팩트 — 운영 추정 vs 합성 벤치 가설
+
+#### 운영 환경 추정 📂
+
+| 항목 | Before | After |
+|---|---|---|
+| 외부 호출 수 (동시 20 요청) | 20 | 1 |
+| 다른 IP 할당 (80초 윈도우) | 10 | 1 |
+| 외부 시스템 보안 차단 | 발생 | 0 (24h 모니터링) |
+| 영향받은 customer (24h) | 5 명 | 0 명 |
+
+→ 외부 SaaS + 실 customer + 프록시 풀의 **운영 환경 측정**. 합성 벤치로 정확히 재현 불가.
+
+#### 합성 벤치 가설 🎯 (Phase 2~6 에서 검증 예정)
+
+| Scenario | Metric | Baseline | Coalesced | Δ (가설) |
+|---|---|---|---|---|
+| **S1 — Burst** (100 동시) | 외부 호출 | 100 | 1 | 100× |
+| **S1 — Burst** | P99 | ~500ms | ~500ms | — (모두 owner 응답 대기) |
+| **S2 — Sustained + cache** | 외부 호출 (60s) | ~6,000 | ~1 | 6000× (cache+SF 합산) |
+| **S2 — Sustained + cache** | P99 | 850ms | ~5ms | 170× (cache hit) |
+| **S3 — Pure SF (no cache)** | 외부 호출 (60s) | ~6,000 | ~120 | 50× (SF 만의 효과) |
+
+→ **"P99 850→32ms" 같은 수치는 S2 (cache + SF 합산) 의 가설**. 운영 incident 의 P99 는 외부 SaaS 응답 변동성 등 추가 변수로 직접 비교 불가.
+
+📊 실측은 Phase 2 (MVC) / Phase 3 (Redis) / Phase 6 (WebFlux) 완료 시 [BENCHMARK.md](BENCHMARK.md) 의 각 Phase 표로 갱신.
+
+→ **면접에서 cite 시 라벨 명시 필수**. "운영 추정 / 합성 벤치 가설 / Phase X 실측" 어느 출처인지 즉답.
 
 ### 비즈니스 임팩트 (정량 추정)
 

--- a/docs/STORY.md
+++ b/docs/STORY.md
@@ -229,6 +229,90 @@ async ensureSession(userId) {
 
 **채택**. **Single-Flight + Hexagonal (multi-instance 확장 여지) + Decorator stack (운영 안전망)** 을 종합 설계.
 
+### Meta-Decision — 왜 Hexagonal 까지 했는가?
+
+위 4 alternative 는 **lock 메커니즘** 의 비교. 그런데 Single-Flight 채택 후 추가 결정이 하나 더:
+
+> "Single-Flight 를 NaverService 에 inline 으로 박을 것인가, Port/Adapter 추상화로 분리할 것인가?"
+
+이게 **architectural-level decision**. 두 옵션:
+
+#### Meta-Option α — Inline (단순 utility)
+
+```java
+// NaverService.java
+@Service
+public class NaverService {
+    private final ConcurrentHashMap<String, CompletableFuture<Session>> inflight = new ConcurrentHashMap<>();
+
+    public CompletableFuture<Session> ensureSession(String userId) {
+        return inflight.computeIfAbsent(userId, k ->
+            doEnsureSession(k).whenComplete((v, e) -> inflight.remove(k))
+        );
+    }
+}
+```
+
+→ **30 줄 추가로 incident 즉시 차단.** YAGNI 정직.
+
+**Pros**:
+- 가장 단순. Boilerplate 0.
+- 빠른 시작. 즉시 production 배포 가능.
+
+**Cons**:
+- ❌ Multi-instance 갈 때 NaverService 다시 수정
+- ❌ Telemetry / Deadline / Capacity 도 NaverService 안에 박힘 (SRP 위반)
+- ❌ 다른 도메인 (CPEATS, BAEMIN) 에 같은 패턴 적용 시 코드 중복
+
+#### Meta-Option β — Hexagonal (Port/Adapter)
+
+```java
+public interface SingleFlightCoordinator { ... }
+
+class InProcessSingleFlightCoordinator implements SingleFlightCoordinator { ... }
+class RedisSingleFlightCoordinator implements SingleFlightCoordinator { ... }
+
+@Service
+public class NaverService {
+    private final SingleFlightCoordinator coordinator;  // Port 만 의존
+    public CompletableFuture<Session> ensureSession(String userId) {
+        return coordinator.execute(userId, () -> doEnsureSession(userId));
+    }
+}
+```
+
+→ **약 1000 줄** (Port + Adapter + Decorator 4개 + 테스트). 약 3-5일 작업.
+
+**Pros**:
+- ✅ Multi-instance 갈 때 NaverService 수정 0
+- ✅ Decorator 4개 (Telemetry / Heartbeat / Capacity / Deadline) SRP 분리
+- ✅ 다른 도메인 재사용
+- ✅ Framework 독립성
+
+**Cons**:
+- ❌ 약 30× 코드 양 (단순 인라인 대비)
+- ❌ 추상화 학습 비용
+- ❌ 단일 backend 평생 쓸 거면 over-engineering
+
+#### 채택 — Meta-Option β
+
+근거 4 시그널 ([ADR-001](adr/ADR-001-port-adapter-pattern.md) 의 "Decision Signals"):
+
+| 시그널 | 우리 case |
+|---|---|
+| 여러 backend 실제 필요 | ✅ Phase 3 Redis 명시 |
+| 도메인 코드 backend 영향 X | ✅ NaverService 보호 |
+| Port API 안정성 | ✅ 4 메서드 충분 |
+| Framework 독립성 가치 | ✅ Spring 0 의존 |
+
+**4/4 해당.** Hexagonal 의 추가 cost (약 1000줄) 가 정당화되는 case.
+
+#### 만약 시그널 0~1개만 해당했다면?
+
+→ **Meta-Option α (inline) 가 정답.** Over-engineering 회피. 두 번째 backend 가 명백해진 시점에 그때 추상화 (refactoring with TDD).
+
+이 판단이 시니어 시그널: **"Hexagonal 자체에 대한 고집이 아니라 case 분석"**. 만약 모든 프로젝트에 무조건 Hexagonal 적용한다면 그게 cargo cult.
+
 ---
 
 ## Act 5 — The Solution

--- a/docs/adr/ADR-001-port-adapter-pattern.md
+++ b/docs/adr/ADR-001-port-adapter-pattern.md
@@ -1,0 +1,294 @@
+# ADR-001 — Adopt Port/Adapter (Hexagonal) Pattern for Single-Flight Coordinator
+
+| Field | Value |
+|---|---|
+| Status | **Proposed** (Phase 1 구현 완료 시 Accepted) |
+| Date | 2026-04-25 |
+| Phase | 1 |
+| Deciders | @PreAgile |
+| Related | [ADR-002](ADR-002-in-process-vs-redis-lock.md), [ADR-003](ADR-003-decorator-stack-order.md), [ADR-004](ADR-004-coordinator-vs-caffeine.md) |
+
+---
+
+## Context
+
+운영 incident ([INCIDENT.md](../INCIDENT.md)) 의 RCA 로 Single-Flight 패턴 도입 결정.
+구현 시 architectural 선택지가 여러 개:
+
+1. **단일 클래스 직접 구현** — `NaverService` 안에 inline 으로 Map + Promise.race
+2. **Port/Adapter (Hexagonal)** — 인터페이스 정의 + 여러 backend 구현 가능
+3. **Spring AOP `@Around`** — Bean 메서드에 cross-cutting 으로 주입
+
+선택 기준:
+- 도메인 로직 (NaverService) 의 변경 최소화
+- 미래 확장 (in-process → Redis → MQ routing) 에 유연
+- 테스트 용이성
+- Framework 의존성 최소
+
+---
+
+## Decision
+
+**Port/Adapter (Hexagonal) 패턴 채택.**
+
+### Port — `SingleFlightCoordinator` 인터페이스
+
+```java
+public interface SingleFlightCoordinator {
+    <T> CompletableFuture<T> execute(String key, Supplier<CompletableFuture<T>> operation);
+    <T> CompletableFuture<T> execute(String key, Supplier<CompletableFuture<T>> operation, SingleFlightOptions options);
+    List<InflightEntry> getInflightState();
+    CompletableFuture<Void> forceRelease(String key, String reason);
+}
+```
+
+도메인 service (NaverService 같은) 는 이 인터페이스만 의존.
+
+### Adapter Variants
+
+- **InProcess** (Phase 1) — `ConcurrentHashMap.computeIfAbsent`. 단일 JVM.
+- **Redis** (Phase 3) — `SETNX + Lua + Pub/Sub`. 멀티 인스턴스.
+- **(미래)** MQ routing layer — InProcess 와 합성.
+
+### 합성 — Decorator Stack
+
+[ADR-003](ADR-003-decorator-stack-order.md) 참고. 4 decorator (Telemetry / Heartbeat / Capacity / Deadline) 가 inner adapter 를 wrap.
+
+---
+
+## Consequences
+
+### Positive
+
+✅ **Backend swap**: NaverService 코드 수정 없이 in-process → Redis → MQ 전환 가능.
+✅ **Framework-independent core**: `coordinator-core` 모듈은 Spring 의존성 0. 어떤 Java framework (Spring, Quarkus, Micronaut, plain Tomcat) 에든 임베드 가능.
+✅ **Testability**: 각 Adapter / Decorator 가 단위 테스트 가능. Mock Coordinator 로 NaverService 도 격리 테스트.
+✅ **Composition**: Decorator 4개를 필요한 조합으로 stack. 환경별 다른 stack (개발/프로덕션) 가능.
+✅ **Portfolio 시그널**: Hexagonal Architecture 이해 + 추상화 깊이 어필.
+
+### Negative
+
+❌ **간접화 비용**: 단순 use case 에 인터페이스 + 구현 + factory 가 boilerplate.
+❌ **Generic type 복잡성**: `<T>` 가 Java 타입 시스템에서 어색 (cast 필요한 영역 있음).
+❌ **DI 설정 복잡**: 5 layer chain 합성을 factory 함수에서 명시. 단순 `@Bean` 만으론 부족.
+
+### Neutral
+
+⚪ **러닝 커브**: 새 팀원이 합성 chain 이해하는 데 시간 필요. 단 [DESIGN.md](../DESIGN.md) 가 답.
+
+---
+
+## Alternatives Considered
+
+### Alternative A — Direct Implementation in NaverService
+
+```java
+@Service
+public class NaverService {
+    private final ConcurrentHashMap<String, CompletableFuture<Session>> inflight = new ConcurrentHashMap<>();
+
+    public CompletableFuture<Session> ensureSession(String userId) {
+        return inflight.computeIfAbsent(userId, k ->
+            doEnsureSession(k).whenComplete((v, e) -> inflight.remove(k))
+        );
+    }
+}
+```
+
+**Pros**:
+- 단순. Boilerplate 0.
+- Phase 1 코드 50% 감소.
+
+**Cons**:
+- ❌ Multi-instance 갈 때 NaverService 직접 수정 (도메인 vs 인프라 분리 깨짐)
+- ❌ Telemetry / Deadline / Capacity 도 NaverService 안에 박혀야 함 (SRP 위반)
+- ❌ 다른 도메인 (CPEATS, BAEMIN) 에 같은 패턴 적용 시 코드 중복
+- ❌ Portfolio 측면에서 architectural 깊이 부족
+
+**Verdict**: Phase 1 단독 보면 합리적이지만, **Phase 3 (Redis 확장) + 다른 도메인 적용 시점에 부담 폭발**. 미리 추상화.
+
+---
+
+### Alternative B — Spring AOP `@Around`
+
+```java
+@Aspect
+@Component
+public class SingleFlightAspect {
+    private final ConcurrentHashMap<String, CompletableFuture<?>> inflight = new ConcurrentHashMap<>();
+
+    @Around("@annotation(SingleFlight)")
+    public Object coalesce(ProceedingJoinPoint pjp, SingleFlight ann) throws Throwable {
+        String key = extractKey(pjp, ann.keyExpression());
+        return inflight.computeIfAbsent(key, k -> {
+            try { return (CompletableFuture<?>) pjp.proceed(); }
+            catch (Throwable e) { throw new RuntimeException(e); }
+        });
+    }
+}
+
+@Service
+public class NaverService {
+    @SingleFlight(keyExpression = "#userId")
+    public CompletableFuture<Session> ensureSession(String userId) { ... }
+}
+```
+
+**Pros**:
+- 사용자 편의 (annotation 하나로 적용)
+- Bean 단위 적용 자연스러움
+
+**Cons**:
+- ❌ **Spring 강결합** — coordinator-core 가 framework-independent 라는 원칙 어김
+- ❌ Proxy chain 디버깅 어려움 (stack trace 가 Spring CGLib 으로 채워짐)
+- ❌ Cross-cutting 다중 concern (deadline + capacity + telemetry) 각자 aspect 면 stack 순서 모호
+- ❌ Test 시 Spring context 필수 (단위 테스트 무거움)
+- ❌ Decorator 의 명시적 stack 보다 가독성 약함
+
+**Verdict**: Spring 헤비 환경에선 매력적이지만, **library-first portfolio** 가치엔 안 맞음.
+
+---
+
+### Alternative C — Library 직접 사용 (Caffeine.AsyncCache)
+
+```java
+AsyncLoadingCache<String, Session> cache = Caffeine.newBuilder()
+    .expireAfterWrite(Duration.ofMinutes(5))
+    .buildAsync(key -> doEnsureSession(key));
+
+CompletableFuture<Session> session = cache.get("user-X");  // coalesce 내장
+```
+
+**Pros**:
+- 작성 코드 0
+- 검증된 라이브러리 (millions of downloads)
+
+**Cons**:
+- ❌ Cache 가정 하에 동작 (TTL, eviction). 우리 use case 는 cache 가 아니라 session 외부 자원 할당
+- ❌ Deadline / Capacity / Telemetry 통합 제어 불가 (각각 Caffeine 외부에서 별도 wrap)
+- ❌ Caffeine 강결합 → 미래 Redis backend 로 swap 어려움 (Caffeine 인터페이스 구현 안 함)
+- ❌ Portfolio 측면: "Caffeine 썼어요" 보다 "직접 구현했고 그 이유는..." 이 시니어 시그널
+
+상세 비교: [ADR-004](ADR-004-coordinator-vs-caffeine.md)
+
+**Verdict**: 일부 use case 에는 적합하지만, 운영 안전망 통합 + multi-backend 확장이 핵심 목적이라 직접 구현.
+
+---
+
+## Implementation Notes
+
+### Module Structure
+
+```
+coordinator-core/                Pure Java (no Spring)
+├── coordinator/
+│   ├── SingleFlightCoordinator.java       (Port)
+│   ├── SingleFlightOptions.java
+│   ├── InflightEntry.java
+│   ├── adapter/
+│   │   ├── InProcessSingleFlightCoordinator.java   (Phase 1)
+│   │   └── RedisSingleFlightCoordinator.java       (Phase 3)
+│   ├── decorator/
+│   │   ├── DeadlineDecorator.java
+│   │   ├── CapacityDecorator.java
+│   │   ├── HeartbeatDecorator.java
+│   │   └── TelemetryDecorator.java
+│   └── exception/...
+
+mvc-demo/                        Spring MVC consumer
+└── coordinator-core 의존
+└── factory @Bean 으로 chain 합성
+```
+
+### Factory 패턴 — 합성
+
+```java
+@Configuration
+public class CoordinatorBeans {
+    @Bean
+    public SingleFlightCoordinator naverEnsureSessionCoordinator(
+        MetricRegistry metrics,
+        SingleFlightProperties props
+    ) {
+        SingleFlightCoordinator base = new InProcessSingleFlightCoordinator();
+
+        SingleFlightCoordinator stacked = new TelemetryDecorator(
+            new HeartbeatDecorator(
+                new CapacityDecorator(
+                    new DeadlineDecorator(base, props.getDefaultDeadline()),
+                    props.getMaxWaiters()
+                ),
+                Duration.ofSeconds(15),
+                Duration.ofSeconds(60)
+            ),
+            metrics,
+            "naver-ensure-session"
+        );
+
+        return stacked;
+    }
+}
+```
+
+→ Decorator 순서 명시적. 환경 (개발/프로덕션) 별 stack 변경 가능.
+
+### Test Strategy
+
+각 layer 단위 테스트 + 합성 통합 테스트:
+
+```
+unit:
+  InProcessSingleFlightCoordinatorTest    — 7 시나리오
+  DeadlineDecoratorTest                    — 4 시나리오
+  CapacityDecoratorTest                    — 4 시나리오
+  HeartbeatDecoratorTest                   — 3 시나리오
+  TelemetryDecoratorTest                   — 5 시나리오
+
+integration:
+  FullChainTest                            — 5 layer 합성 (4 시나리오)
+                                             • coalesce
+                                             • deadline propagation
+                                             • capacity rejection
+                                             • telemetry classification
+```
+
+→ 각 단위 테스트는 Mock 또는 spy 로 inner 격리. 합성 테스트는 실 chain 사용.
+
+---
+
+## Validation — How We'll Know This Is Right
+
+### Phase 1 완료 시 확인:
+- [ ] `coordinator-core` 가 `@SpringBootApplication` 없이 빌드/테스트 가능
+- [ ] `coordinator-core` 의 `build.gradle.kts` 에 Spring 의존성 0
+- [ ] 단위 테스트 27개 통과
+- [ ] mvc-demo 가 `coordinator-core` 를 deps 로 import 후 즉시 사용 가능
+
+### Phase 3 완료 시 확인:
+- [ ] `RedisSingleFlightCoordinator` 추가만으로 NaverService 코드 0 수정
+- [ ] `application-coalesce-redis.yml` profile 토글로 backend 전환
+- [ ] 4 Decorator 가 in-process 와 Redis backend 모두에 작동
+
+### 만약 이게 깨지면 (이 ADR 가 잘못된 경우):
+- "재구현 시 NaverService 도 수정해야 했다" → 추상화가 새는 신호
+- "Decorator 의 inner 가 backend specific 동작에 의존" → port 가 충분히 추상적이지 않음
+- "Test 가 무거워짐 (Spring 필요)" → coordinator-core 의 의존성 침범
+
+→ 위 시그널 발견되면 ADR-001 revision.
+
+---
+
+## References
+
+- [Hexagonal Architecture by Alistair Cockburn](https://alistair.cockburn.us/hexagonal-architecture/)
+- [Decorator Pattern (GoF)](https://en.wikipedia.org/wiki/Decorator_pattern)
+- [Effective Java 3rd ed., Item 18 — Composition over inheritance](https://www.oreilly.com/library/view/effective-java-3rd/9780134686097/)
+- Go `singleflight` 패키지: https://pkg.go.dev/golang.org/x/sync/singleflight (명명의 어원)
+- 도메인 service 의 [INCIDENT.md](../INCIDENT.md), [STORY.md](../STORY.md)
+
+---
+
+## Status History
+
+- 2026-04-25: Proposed (Phase 1 시작 시점)
+- TBD: Accepted (Phase 1 구현 완료 + Phase 2 demo 가 정상 동작 확인 시)

--- a/docs/adr/ADR-001-port-adapter-pattern.md
+++ b/docs/adr/ADR-001-port-adapter-pattern.md
@@ -31,6 +31,25 @@
 
 **Port/Adapter (Hexagonal) 패턴 채택.**
 
+### Decision Signals — 왜 이 case 가 Hexagonal 정당화되는가
+
+Hexagonal 은 **항상 정답이 아니다.** Over-engineering 의 흔한 함정.
+다음 4 시그널 중 **2 개 이상** 해당해야 추상화 비용이 정당화된다.
+
+| # | 시그널 | 우리 case 적용 여부 | 증거 |
+|---|---|:---:|---|
+| **S1** | 여러 backend 구현이 실제로 필요 | ✅ | Phase 3 (Redis) + 미래 MQ routing 명시. ADR-002 가 backend swap 비교. |
+| **S2** | 도메인 코드가 인프라 변경 영향받지 않아야 | ✅ | NaverService 가 `SingleFlightCoordinator` Port 만 의존. Phase 1→3 transition 시 NaverService 수정 0. |
+| **S3** | Port API 가 안정적 (자주 안 바뀜) | ✅ | 4 메서드 (execute / execute+opts / getInflightState / forceRelease). Phase 1~6 진행 동안 변동 없을 예정. |
+| **S4** | Framework 독립성이 가치 있음 | ✅ | `coordinator-core` 가 Spring 의존성 0. Quarkus / Micronaut / plain Java 어디든 임베드 가능. Portfolio 측면 시그널. |
+
+**4/4 해당** → Hexagonal 채택 정당화 충분.
+
+### 만약 0~1 개만 해당했다면?
+
+[Alternative A](#alternative-a--direct-implementation-in-naverservice) (단순 utility class, 30줄) 가 더 적절.
+**YAGNI 정직하게 따르는 게 시니어 시그널.** Hexagonal 자체에 대한 고집은 cargo cult.
+
 ### Port — `SingleFlightCoordinator` 인터페이스
 
 ```java
@@ -172,6 +191,118 @@ CompletableFuture<Session> session = cache.get("user-X");  // coalesce 내장
 상세 비교: [ADR-004](ADR-004-coordinator-vs-caffeine.md)
 
 **Verdict**: 일부 use case 에는 적합하지만, 운영 안전망 통합 + multi-backend 확장이 핵심 목적이라 직접 구현.
+
+---
+
+## When NOT to Use This Pattern — 반대 점검
+
+이 ADR 의 목적은 **"Hexagonal 을 모든 곳에 권장하는 게 아니라"**, 우리 case 가 정당한지 점검하는 것. 다음 4 anti-signal 중 **2 개 이상** 해당하면 Hexagonal 은 over-engineering.
+
+### Anti-Signal A1 — 단일 backend 평생 쓸 가능성 높음
+
+- 예: 작은 startup 의 마이크로서비스가 PostgreSQL 만 쓰고 영원히 그럴 것
+- 미래에 새 backend 추가 가능성 < 30%
+- → 미리 추상화 비용 > 가치
+
+**우리 case**: ❌ 해당 안 됨. Phase 3 의 Redis adapter 가 명시적 다음 단계.
+
+### Anti-Signal A2 — Port 가 thin pass-through
+
+- 인터페이스가 사실상 1 구현체 시그니처 그대로 복사
+- 추상화의 의미가 없음 (변환 / 정책 / 합성 layer 없음)
+- → 인터페이스 + 구현 = boilerplate
+
+**우리 case**: ❌ 해당 안 됨. Port 의 4 메서드가 backend 별 다른 의미 추상:
+- `execute` — InProcess: `computeIfAbsent`. Redis: `SETNX + Lua`. MQ: consistent-hash routing.
+- `getInflightState` — InProcess: Map snapshot. Redis: `KEYS pattern + GET`.
+- `forceRelease` — InProcess: Map remove. Redis: Lua delete.
+
+추상화의 의미가 명확.
+
+### Anti-Signal A3 — 팀 작고 코드베이스 작고 변경 빈도 낮음
+
+- 추상화 maintenance cost > 가치
+- 새 팀원이 이해하는 데 비용 > 추상화의 코드 보호 효과
+- → 단순 utility class 가 정답
+
+**우리 case**: 부분 해당 (portfolio repo 라 small). 단:
+- 변경 빈도가 낮은 게 오히려 Port 안정성 시그널 (S3)
+- 다른 도메인 (CPEATS, BAEMIN) 에 같은 패턴 적용 가능성도 고려
+- → 부분 해당이지만 다른 시그널이 압도
+
+### Anti-Signal A4 — Framework 강결합 OK
+
+- 평생 Spring 만 쓸 거라면 Spring AOP 가 더 단순
+- coordinator-core 의 framework 독립성이 비용 이상의 가치 못 만들면 Hexagonal 약화
+
+**우리 case**: ❌ 해당 안 됨. Portfolio 측면에서 framework 독립성 자체가 시니어 시그널. `coordinator-core` 의 의존성 그래프에 Spring 0.
+
+### 점검 결과
+
+```
+Decision Signals (정당화):  4 / 4 해당  →  강한 정당화
+Anti-Signals (반대):        0~1 / 4 해당  →  약한 반대
+```
+
+→ **순 정당화 4점.** Hexagonal 채택 정당.
+
+만약 **Anti-Signal 이 2개 이상 해당했다면**: ADR-001 의 Decision 을 [Alternative A](#alternative-a--direct-implementation-in-naverservice) (직접 구현) 로 revision.
+
+---
+
+## Cost-Benefit Analysis
+
+추상화의 **비용 vs 이익** 정량화 (best effort):
+
+### Cost (추상화 비용)
+
+```
+[코드 작성 비용]
+  - Port interface (40 lines)
+  - InProcess adapter (60 lines, 단순 구현 대비 +20 lines)
+  - 4 Decorator (각 60 lines × 4 = 240 lines)
+  - Factory + DI 설정 (50 lines)
+  - 단위 테스트 (300 lines, 단순 utility 대비 +200 lines)
+  - 문서화 (ADR + DESIGN 약 800 lines)
+  
+  → 총 추상화 overhead 약 1,000 lines, 약 3-5 일 작업
+
+[유지보수 비용]
+  - 새 팀원 onboarding 시 추상화 chain 이해 (2-3 시간)
+  - 새 backend 추가 시 Port 시그니처 검증 (1 일 / backend)
+  - Decorator 순서 변경 시 ADR 갱신
+```
+
+### Benefit (이익)
+
+```
+[기술적 이익]
+  - Phase 3 Redis 추가 시 NaverService 수정 0 (절약 ~2 일)
+  - 다른 도메인 (CPEATS, BAEMIN) 에 같은 패턴 적용 (절약 ~5 일/도메인)
+  - 테스트 격리 (각 layer 독립 — 디버깅 시간 절약)
+  - 환경별 stack 변경 가능 (dev/prod)
+
+[Portfolio 이익]
+  - "Hexagonal 이해" 시그널 (면접 가치)
+  - ADR + 다이어그램 → architecture 토론 자료
+  - "이 라이브러리는 framework 무관" 발언 가능
+  - cross-paradigm (MVC vs WebFlux) 비교 가능 (같은 Port 두 backend)
+
+[비즈니스 이익 — 회사 컨텍스트]
+  - Phase 3 Redis 도입 시 incident free transition (이미 검증된 추상화)
+  - 다음 6개월에 새 도메인 적용 시 코드 재사용
+```
+
+### Verdict
+
+```
+Cost ≈ 1000 lines + 3-5 일
+Benefit ≈ Phase 3 transition 절약 + 다른 도메인 재사용 + portfolio + 미래 backend
+```
+
+**Phase 3 의 Redis adapter 가 첫 번째 ROI 검증 포인트.** 만약 Phase 3 가 NaverService 수정 0 으로 통과하면 Cost 회수 + 다음 backend 마다 추가 ROI.
+
+만약 Phase 3 에서 Port 시그니처 변경이 필요해지면? → ADR-001 revision + 추상화의 한계 인식 (정직한 회고).
 
 ---
 

--- a/docs/adr/ADR-002-in-process-vs-redis-lock.md
+++ b/docs/adr/ADR-002-in-process-vs-redis-lock.md
@@ -1,0 +1,82 @@
+# ADR-002 — In-Process vs Redis Lock for Multi-Instance Coalescing
+
+| Field | Value |
+|---|---|
+| Status | **📅 Planned** (Phase 3 시작 시 작성) |
+| Date | TBD |
+| Phase | 3 |
+| Deciders | @PreAgile |
+| Related | [ADR-001](ADR-001-port-adapter-pattern.md), [ADR-003](ADR-003-decorator-stack-order.md) |
+
+---
+
+## Status: Planned
+
+이 ADR 은 **placeholder** 입니다. Phase 3 (Redis Adapter) 시작 시 실제 결정 + 측정값으로 채워집니다.
+
+현재 시점의 가설 / 검토 dimension 만 outline.
+
+---
+
+## Planned Context
+
+Phase 1 의 InProcess adapter 는 단일 JVM 한정. 멀티 인스턴스 환경 (K8s scale-out, rolling deploy) 에서 cross-instance coalesce 필요.
+
+## Planned Decision Dimensions
+
+채택 시 평가할 7 axis:
+
+| Dimension | InProcess | Redis | 결정 영향 |
+|---|---|---|---|
+| Latency overhead | ~0.1ms | ~3-10ms (Redis RTT) | 단일 인스턴스면 InProcess |
+| Multi-instance coalesce | ❌ | ✅ | 멀티면 Redis 필수 |
+| Failure mode | Process crash → all inflight 손실 | TTL 만료 후 재배정 | Redis 가 더 robust |
+| SPOF | None | Redis (mitigation 필요) | 운영 복잡성 |
+| Lock semantics | atomic computeIfAbsent | SETNX + Lua | 정확성 동일 |
+| Result propagation | Promise sharing | Pub/Sub or polling | Redis 는 별도 메커니즘 |
+| Operational complexity | Zero | Redis 의존 추가 | 운영 부담 |
+
+## Planned Alternatives
+
+채택 시 비교할 옵션:
+
+### Alternative A — InProcess only (현재)
+- 단일 인스턴스 평생, 멀티 인스턴스 안 가는 케이스
+
+### Alternative B — Redis SETNX + Lua + Pub/Sub
+- 분산 락 + 결과 broadcast
+- 우리가 가장 강력한 후보로 보는 방향
+
+### Alternative C — Redis SETNX + Polling
+- 분산 락 + waiter 가 결과 polling
+- Pub/Sub 없는 경량 버전
+
+### Alternative D — DB row lock (`SELECT FOR UPDATE`)
+- 이미 DB 있다면 추가 의존성 없음
+- DB 부하 증가 risk
+
+### Alternative E — Hybrid (InProcess + Redis fallback)
+- InProcess 우선, miss 시 Redis 검색
+- 복잡성 vs 성능 trade-off
+
+## Planned Validation
+
+Phase 3 측정으로 검증할 hypothesis:
+
+- 🎯 H1: InProcess 단일 인스턴스 P99 vs Redis 단일 인스턴스 P99 차이는 5-10ms
+- 🎯 H2: 2 인스턴스 환경에서 InProcess (race 발생) vs Redis (cross-coalesce) 외부 호출 수 차이
+- 🎯 H3: Redis 장애 시 fallback 정책의 적절성
+
+## To Be Filled
+
+- [ ] Phase 3 시작 시 Status: Proposed 로 변경
+- [ ] Concrete Decision (어떤 Alternative 채택)
+- [ ] Implementation notes (Redisson vs raw Lua, lock TTL 값, Pub/Sub vs polling)
+- [ ] Measured results (H1~H3 검증)
+- [ ] Phase 3 완료 시 Status: Accepted
+
+## References (Planned)
+
+- [Distributed lock by Martin Kleppmann](https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html)
+- Redisson docs: https://redisson.org/
+- ADR-001 (Port/Adapter — 이 ADR 의 전제)

--- a/docs/adr/ADR-003-decorator-stack-order.md
+++ b/docs/adr/ADR-003-decorator-stack-order.md
@@ -1,0 +1,51 @@
+# ADR-003 — Decorator Stack Order
+
+| Field | Value |
+|---|---|
+| Status | **📅 Planned** (Phase 4 시작 시 작성) |
+| Date | TBD |
+| Phase | 4 |
+| Deciders | @PreAgile |
+| Related | [ADR-001](ADR-001-port-adapter-pattern.md), [ADR-004](ADR-004-coordinator-vs-caffeine.md) |
+
+---
+
+## Status: Planned
+
+이 ADR 은 **placeholder** 입니다. Phase 4 (Cross-language) 시작 시 실제 결정 + 검증으로 채워집니다.
+
+현재까지의 hypothesis 만 outline.
+
+---
+
+## Planned Context
+
+5 layer chain 의 decorator 순서가 의미 가짐:
+
+```
+Base (InProcess) → Deadline → Capacity → Heartbeat → Telemetry (outermost)
+```
+
+순서가 바뀌면:
+- Telemetry 가 inner 면 deadline exception 분류 못 함 (status=hang 으로 보임)
+- Capacity 가 Base 와 분리되면 atomic 검사 깨짐 ([ADR-001 의 capacity nuance](ADR-001-port-adapter-pattern.md) 참고)
+
+## Planned Hypothesis
+
+🎯 **H1**: Telemetry 가 outermost 일 때 deadline / congestion 분류 정확.
+🎯 **H2**: Capacity 가 Base 와 atomic 결합 안 되면 race condition 발생.
+🎯 **H3**: Heartbeat 의 timer 시작은 base record 와 같은 thread context 에서.
+
+## Planned Validation
+
+Phase 4 의 cross-paradigm 검증으로:
+- 같은 stack 순서가 TS / Java 둘 다 옳은가
+- 순서 바뀌면 어떤 시나리오에서 깨지는지 ConcreteTest 로 시연
+
+## To Be Filled
+
+- [ ] Phase 4 시작 시 Status: Proposed
+- [ ] Concrete decision: 정확한 stack 순서 + 각 위치 이유
+- [ ] Anti-pattern: 순서 바꾸면 어떤 bug
+- [ ] TS reference 와 Java 가 같은 순서 채택하는지 비교
+- [ ] Phase 4 완료 시 Status: Accepted

--- a/docs/adr/ADR-004-coordinator-vs-caffeine.md
+++ b/docs/adr/ADR-004-coordinator-vs-caffeine.md
@@ -1,0 +1,81 @@
+# ADR-004 — Coordinator vs Caffeine.AsyncCache
+
+| Field | Value |
+|---|---|
+| Status | **📅 Planned** (Phase 4 시작 시 작성) |
+| Date | TBD |
+| Phase | 4 |
+| Deciders | @PreAgile |
+| Related | [ADR-001](ADR-001-port-adapter-pattern.md) |
+
+---
+
+## Status: Planned
+
+이 ADR 은 **placeholder** 입니다. Phase 4 시작 시 실제 비교 + 측정으로 채워집니다.
+
+현재까지의 hypothesis 만 outline.
+
+---
+
+## Planned Context
+
+[Caffeine.AsyncCache](https://github.com/ben-manes/caffeine) 의 `AsyncLoadingCache` 가 single-flight 와 비슷한 coalescing 을 내장 제공:
+
+```java
+AsyncLoadingCache<String, Session> cache = Caffeine.newBuilder()
+    .expireAfterWrite(Duration.ofMinutes(5))
+    .buildAsync(key -> doEnsureSession(key));
+
+CompletableFuture<Session> session = cache.get("user-X");  // coalesce 내장
+```
+
+→ "왜 Caffeine 안 쓰고 직접 구현?" 이 면접 자주 나오는 꼬리질문 ([INTERVIEW.md Q1](../INTERVIEW.md)).
+
+## Planned Comparison Dimensions
+
+| Dimension | Caffeine.AsyncCache | Coordinator (직접) |
+|---|---|---|
+| Coalescing 정확성 | 검증된 라이브러리 | 직접 구현 (검증 필요) |
+| 결과 보관 (TTL) | 내장 | 별도 cache 필요 |
+| Use case 가정 | Cache (read-heavy) | 일반 비동기 작업 |
+| Deadline / Capacity / Telemetry 통합 | 외부 wrap 필요 | Decorator stack 으로 통합 |
+| Multi-backend 확장 (Redis 등) | Caffeine 인터페이스 구현 안 함 | Port/Adapter 자연 |
+| Maintenance | 라이브러리 의존 | 자체 책임 |
+
+## Planned Hypothesis
+
+🎯 **H1**: Caffeine.AsyncCache 는 cache use case 에 최적, 일반 외부 자원 할당 (login, RPC) 에는 추가 wrap 필요.
+🎯 **H2**: 운영 안전망 (deadline / capacity / telemetry) 통합 제어가 필요한 경우 직접 구현이 명확.
+🎯 **H3**: Multi-backend 확장 (Redis) 이 명시적 다음 단계면 Hexagonal Port 가 더 자연스러움.
+
+## When Caffeine Wins (예상)
+
+- 단순 read cache (TTL 만료 + coalesce 내장)
+- Java/Spring 한정
+- 단일 인스턴스 평생
+- 운영 안전망 단순 (timeout + 기본 metric 만 필요)
+
+## When Direct Coordinator Wins (예상)
+
+- 외부 자원 할당 (cache 가 아니라 작업 자체)
+- 운영 안전망 통합 (4 decorator stack)
+- Multi-backend 확장 예정 (in-process → Redis → MQ)
+- Cross-language reference 필요 (TS, Kotlin 비교 가능)
+
+→ **우리 case 는 후자 4 가지 모두 해당** → 직접 구현.
+
+## Planned Validation
+
+Phase 4 에서 작은 demo 로 비교:
+- 같은 시나리오 (100 동시 요청, 500ms external) 를 Caffeine vs Coordinator 로 풀고
+- 코드 라인 수 비교
+- Decorator 통합 시 Caffeine wrap 의 복잡도 측정
+
+## To Be Filled
+
+- [ ] Phase 4 시작 시 Status: Proposed
+- [ ] Concrete code sample 비교
+- [ ] 측정값 (코드 라인 / 통합 비용 / 성능)
+- [ ] "어떤 case 어떤 도구" 가이드
+- [ ] Phase 4 완료 시 Status: Accepted

--- a/docs/adr/ADR-005-reactive-vs-sync-coalescing.md
+++ b/docs/adr/ADR-005-reactive-vs-sync-coalescing.md
@@ -1,0 +1,123 @@
+# ADR-005 — Reactive vs Sync Coalescing
+
+| Field | Value |
+|---|---|
+| Status | **📅 Planned** (Phase 6 시작 시 작성) |
+| Date | TBD |
+| Phase | 6 |
+| Deciders | @PreAgile |
+| Related | [ADR-001](ADR-001-port-adapter-pattern.md), [ADR-003](ADR-003-decorator-stack-order.md) |
+
+---
+
+## Status: Planned
+
+이 ADR 은 **placeholder** 입니다. Phase 6 (WebFlux Demo) 시작 시 실제 결정 + 측정으로 채워집니다.
+
+현재까지의 hypothesis 만 outline.
+
+---
+
+## Planned Context
+
+Phase 1~5 까지의 Coordinator 는 sync API (`CompletableFuture<T>`) 기반.
+Phase 6 의 WebFlux 환경에선 reactive API (`Mono<T>`) 가 자연스러움.
+
+선택지:
+1. Sync API 그대로 + WebFlux 측에서 변환 (`Mono.fromFuture`)
+2. Reactive 전용 별도 Port (`ReactiveSingleFlightCoordinator`)
+3. 단일 Port 가 둘 다 (overload methods)
+
+## Planned Comparison
+
+| Approach | Pros | Cons |
+|---|---|---|
+| **A. Sync only + Mono.fromFuture wrap** | Port 단일, Java 표준 | Reactor backpressure 손실 |
+| **B. Reactive 전용 Port 분리** | Reactor idiom 자연 (Sinks.One), backpressure 보존 | Port 2개 (ReactiveSingleFlightCoordinator) |
+| **C. 단일 Port + overload** | API 통합 | 인터페이스 복잡, polymorphism issue |
+
+## Planned Hypothesis
+
+🎯 **H1**: WebFlux 의 backpressure 와 cancellation 을 살리려면 reactive 전용 Port 가 자연스러움.
+🎯 **H2**: `Mono.cache()` 의 함정 (TTL 없음, 실패 캐시) 을 회피하려면 `Sinks.One` 기반 직접 구현 필요.
+🎯 **H3**: Sync 와 reactive 의 본질은 같음 — coalesce 알고리즘 (`computeIfAbsent` style) 동일, idiom 만 다름.
+
+## Planned Reactive Implementation Sketch
+
+```java
+public interface ReactiveSingleFlightCoordinator {
+    <T> Mono<T> execute(String key, Supplier<Mono<T>> operation);
+    // ... rest of port
+}
+
+public class ReactiveInProcessCoordinator implements ReactiveSingleFlightCoordinator {
+    private final ConcurrentHashMap<String, Sinks.One<?>> inflight = new ConcurrentHashMap<>();
+
+    @Override
+    public <T> Mono<T> execute(String key, Supplier<Mono<T>> op) {
+        @SuppressWarnings("unchecked")
+        Sinks.One<T> sink = (Sinks.One<T>) inflight.computeIfAbsent(key, k -> {
+            Sinks.One<T> s = Sinks.one();
+            op.get().subscribe(
+                v -> { s.tryEmitValue(v); inflight.remove(k); },
+                e -> { s.tryEmitError(e); inflight.remove(k); }
+            );
+            return s;
+        });
+        return sink.asMono();
+    }
+}
+```
+
+→ Sync 의 `CompletableFuture.whenComplete` 와 reactive 의 `subscribe + tryEmit` 가 isomorphic.
+
+## Planned Pitfalls (Reactive 특화)
+
+🎯 **P1**: `Mono.cache()` 의 함정
+- TTL 없음 (메모리 leak)
+- 실패 시에도 cache (다음 요청도 같은 실패 받음)
+- → 직접 `Sinks.One` 으로 풀어야 함
+
+🎯 **P2**: Hot vs Cold publisher
+- `Sinks.One` 은 hot (외부 trigger 로 emit)
+- 다중 subscribe 시 동일 결과 broadcast
+- Cold 처럼 동작 안 함 → backpressure 의미 다름
+
+🎯 **P3**: Cancellation propagation
+- WebFlux 의 client cancel 시 owner 도 cancel? → 정책 결정 필요
+- 1 caller cancel 해도 다른 waiter 가 있으면 owner 진행 (single-flight 본질)
+
+## Planned Cross-paradigm Comparison
+
+[cross-paradigm/mvc-vs-webflux.md](../cross-paradigm/mvc-vs-webflux.md) 와 연동.
+
+| Idiom | MVC (Java sync) | WebFlux (Reactor) |
+|---|---|---|
+| Result holder | `CompletableFuture<T>` | `Sinks.One<T>` |
+| Cleanup | `whenComplete` | `subscribe(_, _)` 의 둘째 callback |
+| Timeout | `orTimeout` | `Mono.timeout` |
+| Map operation | `computeIfAbsent` | 같음 (둘 다 ConcurrentHashMap) |
+
+→ **본질 동일, idiom 만 다름.** [THESIS.md](../THESIS.md) 의 L3 시연.
+
+## Planned Validation
+
+Phase 6 측정으로:
+- 🎯 같은 시나리오 (100 VU, 500ms downstream) 에서 sync vs reactive 의 외부 호출 수 비교
+- 🎯 backpressure 시나리오 (sustained > processing rate) 에서 reactive 가 sync 대비 어떤 추가 가치
+
+## To Be Filled
+
+- [ ] Phase 6 시작 시 Status: Proposed
+- [ ] Concrete decision (Approach A vs B vs C)
+- [ ] Sinks.One 구현 detail + edge case 처리
+- [ ] 측정 비교 결과
+- [ ] Cross-paradigm chapter 와 cross-link
+- [ ] Phase 6 완료 시 Status: Accepted
+
+## References (Planned)
+
+- Reactor docs: https://projectreactor.io/docs/core/release/reference/
+- `Sinks.One`: https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Sinks.html
+- Backpressure 개념: https://projectreactor.io/docs/core/release/reference/#reactive-streams
+- ADR-001 (Port/Adapter — 이 ADR 의 전제)

--- a/docs/cross-paradigm/mvc-vs-webflux.md
+++ b/docs/cross-paradigm/mvc-vs-webflux.md
@@ -1,0 +1,210 @@
+# MVC vs WebFlux — 같은 Thundering Herd, 다른 자원이 폭주
+
+> ⚠️ **PLACEHOLDER** — Phase 2 (mvc-demo) 와 Phase 6 (webflux-demo) 측정 완료 시 채워짐.
+> 현재는 비교 dimension 만 정의.
+
+[THESIS.md](../THESIS.md) 의 **L3 — 다른 paradigm 비교** 단계의 핵심 챕터.
+
+---
+
+## Why This Comparison Matters
+
+같은 thundering herd 패턴이 동시성 모델별로 **다른 자원으로 표출**됨. 이를 비교해서 새 framework / paradigm 만나도 같은 사고로 적응 가능함을 시연.
+
+---
+
+## Comparison Dimensions
+
+비교할 7개 axis:
+
+### 1. Concurrency Model
+
+| | Spring MVC | Spring WebFlux |
+|---|---|---|
+| 패턴 | Thread-per-request | Event loop + reactive streams |
+| Thread pool | Tomcat (default 200) | Reactor (CPU 코어 수) |
+| Blocking 처리 | Acceptable (대기 thread 점유) | 금지 (event loop 막힘) |
+
+### 2. Thundering Herd 표출 자원
+
+| | Spring MVC | Spring WebFlux |
+|---|---|---|
+| **포화 자원** | **Tomcat thread pool** | **WebClient connection pool** |
+| 보조 자원 | DB connection, 메모리 | Reactor scheduler, connection pool |
+| Saturation 결과 | HTTP 503 (queue 초과) | Connection refused / backpressure overflow |
+
+### 3. SingleFlight 효과
+
+| 효과 | MVC | WebFlux |
+|---|---|---|
+| 외부 호출 N → 1 | ✓ | ✓ |
+| **자원 보호 대상** | **Thread pool** | **Connection pool** |
+| Latency 개선 | P99 850→32ms 추정 | P99 720→28ms 추정 |
+| Throughput 개선 | 25× | 25× |
+
+### 4. 구현 idiom 차이
+
+#### MVC (Java sync)
+```java
+public CompletableFuture<Session> ensureSession(String userId) {
+    return coordinator.execute(userId, () -> doEnsureSession(userId));
+}
+
+// Coordinator 내부:
+ConcurrentHashMap.computeIfAbsent(key, k -> operation.get())
+```
+
+→ `CompletableFuture` 기반. `ConcurrentHashMap.computeIfAbsent` 가 atomic.
+
+#### WebFlux (Reactor)
+```java
+public Mono<Session> ensureSession(String userId) {
+    return reactiveCoordinator.execute(userId, () -> doEnsureSessionReactive(userId));
+}
+
+// Coordinator 내부:
+ConcurrentHashMap<String, Sinks.One<T>> inflight;
+
+return inflight.computeIfAbsent(key, k -> {
+    Sinks.One<T> sink = Sinks.one();
+    op.get().subscribe(
+        v -> { sink.tryEmitValue(v); inflight.remove(k); },
+        e -> { sink.tryEmitError(e); inflight.remove(k); }
+    );
+    return sink;
+}).asMono();
+```
+
+→ `Sinks.One` + `Mono`. Lazy subscribe 본질, multiple waiter 가 같은 sink subscribe.
+
+### 5. 측정 메트릭 차이
+
+#### MVC 핵심 메트릭
+- `tomcat_threads_busy{name=http-nio}` — busy thread 수 (★)
+- `tomcat_threads_max{name=http-nio}` — max
+- `tomcat_threads_busy_ratio` — 점유율 % (★)
+- `http_server_requests_seconds{...}` — request duration
+
+#### WebFlux 핵심 메트릭
+- `reactor_netty_connection_provider_total_connections{name=...}` — connection 수 (★)
+- `reactor_netty_connection_provider_active_connections{name=...}` — active
+- `reactor_netty_connection_provider_pending_acquires{...}` — 대기 중 acquire
+- `reactor_scheduler_queue_size{name=parallel}` — Reactor scheduler queue
+
+### 6. Failure Mode
+
+| Mode | MVC | WebFlux |
+|---|---|---|
+| Pool 포화 | HTTP 503 | Backpressure overflow |
+| Slow downstream | Thread blocked, queue 누적 | Connection 점유, Mono 누적 |
+| Downstream 차단 | Worker thread 점유 → 새 요청 거부 | Connection pool 고갈 |
+| Recovery 시간 | Slow (queued requests timeout 후) | Fast (subscribe cancel 가능) |
+
+### 7. Trade-offs — 어느 모델이 적합한가
+
+| 시나리오 | MVC 권장 | WebFlux 권장 |
+|---|---|---|
+| Downstream 응답 빠름 (< 50ms) | ✅ 단순함이 가치 | (오버헤드 vs 가치) |
+| Downstream 응답 느림 (>500ms) | (thread pool 폭주 우려) | ✅ |
+| 대량 동시 사용자 (10k+) | (thread 비용) | ✅ |
+| 팀 reactive 익숙도 낮음 | ✅ 학습 비용 0 | (러닝 커브) |
+| 디버깅 / observability 우선 | ✅ stack trace 명확 | (Reactor 의 chain 추적 어려움) |
+| Streaming 응답 (SSE, WebSocket) | (제약 있음) | ✅ Mono/Flux 자연 |
+
+---
+
+## Measured Results — TBD
+
+### Phase 2 (MVC) 측정 결과
+> 측정 후 [BENCHMARK.md](../BENCHMARK.md) 의 Phase 2 섹션에서 가져옴.
+
+```
+TBD — Phase 2 완료 시 채움
+```
+
+### Phase 6 (WebFlux) 측정 결과
+> 측정 후 [BENCHMARK.md](../BENCHMARK.md) 의 Phase 6 섹션에서 가져옴.
+
+```
+TBD — Phase 6 완료 시 채움
+```
+
+### 직접 비교 표
+
+```
+TBD — Phase 6 완료 시:
+| Metric                  | MVC Coalesced | WebFlux Coalesced | Diff |
+| External API calls       | 1             | 1                 |      |
+| P99 latency              | 32ms          | 28ms              |      |
+| Tomcat busy thread       | 5%            | N/A               |      |
+| WebClient connections    | N/A           | 1                 |      |
+| Throughput               | 3,000 req/s   | 3,500 req/s       |      |
+```
+
+---
+
+## Visual Comparison — Grafana Dashboards
+
+> Phase 2 + 6 완료 시 캡처 이미지 첨부 예정.
+
+```
+[Phase 2 — MVC Baseline]
+TBD: Tomcat busy thread 100%, P99 850ms
+
+[Phase 2 — MVC Coalesced]
+TBD: Tomcat busy thread 5%, P99 32ms
+
+[Phase 6 — WebFlux Baseline]
+TBD: Connection pool 100%, P99 720ms
+
+[Phase 6 — WebFlux Coalesced]
+TBD: Connection pool 1, P99 28ms
+```
+
+---
+
+## Synthesis — 통합 통찰
+
+> Phase 6 완료 + 측정값 확보 후 작성.
+
+핵심 thesis (예상):
+
+> **같은 thundering herd 패턴이 paradigm 별로 다른 자원으로 표출되지만, 본질은 동일.
+> SingleFlight 의 추상화 (Port/Adapter) 가 충분히 일반적이라 paradigm 별 idiom 만 갈아끼면 적응 가능.**
+
+이 통찰이 [THESIS.md](../THESIS.md) 의 L3 → L5 단계의 핵심 시그널.
+
+---
+
+## Code Cross-Reference
+
+### MVC Implementation
+- `mvc-demo/src/main/java/com/portfolio/demo/mvc/CoalescedMvcController.java`
+- `coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/adapter/InProcessSingleFlightCoordinator.java`
+
+### WebFlux Implementation
+- `webflux-demo/src/main/java/com/portfolio/demo/webflux/CoalescedFluxController.java`
+- `coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/adapter/ReactiveInProcessCoordinator.java`
+
+---
+
+## Future Extensions (v1.1+)
+
+이 비교 챕터를 다음으로 확장:
+
+| Phase | 비교 대상 | 핵심 dimension |
+|---|---|---|
+| 7 | Java 21 Virtual Threads | VT 가 thread 비용 줄이지만 connection 은 그대로 |
+| 8 | Kotlin Coroutines | `Mutex.withLock` + `Deferred` idiom |
+
+→ **4-paradigm 비교** 가 v1.1 의 어필 정점.
+
+---
+
+## Related
+
+- [STORY.md](../STORY.md) — 7-act narrative
+- [DESIGN.md](../DESIGN.md) — Hexagonal + Decorator 설계
+- [BENCHMARK.md](../BENCHMARK.md) — Phase 별 측정 결과
+- [THESIS.md](../THESIS.md) — L0~L5 진화 모델
+- [INTERVIEW.md](../INTERVIEW.md) Q4 — "MVC vs WebFlux 어느 게 더 좋나요?" 답변

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,53 @@
+# Infra — 📅 Planned
+
+> Phase 2 (mvc-demo + 측정 인프라) 시작 시 채워짐.
+
+## Planned Layout
+
+```
+infra/
+├── docker-compose.yml          (Phase 2)
+├── prometheus/
+│   └── prometheus.yml
+└── grafana/
+    ├── provisioning/
+    │   ├── dashboards/default.yml
+    │   └── datasources/prometheus.yml
+    └── dashboards/
+        ├── mvc-single-flight.json
+        └── webflux-single-flight.json (Phase 6)
+```
+
+## Planned Services
+
+- **app** (mvc-demo or webflux-demo) — Spring Boot 3.x
+- **redis** (Phase 3) — 7-alpine
+- **prometheus** — latest, 15s scrape interval
+- **grafana** — latest, admin/admin, dashboards auto-provisioned
+
+## Planned Quick Start
+
+```bash
+# Phase 2 완료 후 동작 예정:
+cd infra && docker-compose up -d
+
+# Grafana
+open http://localhost:3000
+
+# Prometheus
+open http://localhost:9090
+```
+
+## Status
+
+- [ ] Phase 2 시작 시 docker-compose.yml 작성
+- [ ] Prometheus scrape config
+- [ ] Grafana provisioning + dashboard
+- [ ] Phase 3 시작 시 redis service 추가
+- [ ] Phase 6 시작 시 webflux dashboard 추가
+
+## References
+
+- [BENCHMARK.md](../docs/BENCHMARK.md) — 측정 방법론 + 예상 결과
+- [Issue #3 (Phase 2)](https://github.com/PreAgile/single-flight-coordinator-lab/issues/3)
+- [Issue #4 (Phase 3)](https://github.com/PreAgile/single-flight-coordinator-lab/issues/4)


### PR DESCRIPTION
## Summary

Portfolio 의 4-layer narrative architecture 정립. 코드 (Phase 1~) 가 들어가기 전 **narrative skeleton** 을 먼저 깔아서, Phase 진행하면서 incident 디테일 / 측정값 / 비교를 자연스럽게 채울 수 있게 함.

**핵심 thesis** ([docs/THESIS.md](docs/THESIS.md)): "패턴을 안다" 가 아니라 "각 framework 의 본질적 통점을 이해하고 paradigm 별 표출 차이를 측정값으로 비교할 수 있다" 가 시니어 시그널.

## Changes

### narrative centerpiece
- **`docs/STORY.md`** (421 lines) — 7-act narrative
  - Hook (드라마틱 첫 단락)
  - The Incident (Customer A 인간 narrative)
  - The Investigation (탐정 RCA)
  - The Decision (4 대안 비교)
  - The Solution (architecture)
  - The Result (정량 + 비즈니스 임팩트 + counterfactual)
  - The Lesson (배운 것 + 다시 하면 + 일반화)

### supporting docs
- **`docs/INCIDENT.md`** (250 lines) — forensic timeline (KST 분 단위) + Customer A 페르소나 + 24h scope (5명 customer)
- **`docs/INTERVIEW.md`** (266 lines) — STAR 프레임워크 1/5-min + 7 딥다이브 Q&A + 안티 패턴 + pre-flight 체크리스트
- **`docs/BENCHMARK.md`** (342 lines) — 측정 방법론 (warm-up/sustained 규약) + Phase 1~6 expected results + **비즈니스 임팩트 framework** (CS 비용 / churn 위험 / compliance 위험 4 차원)
- **`docs/DESIGN.md`** (429 lines) — Hexagonal + Decorator architecture + Mermaid 시퀀스 다이어그램 + module layout + failure modes
- **`docs/adr/ADR-001-port-adapter-pattern.md`** (294 lines) — Status: Proposed. Decision + 3 alternatives (Direct / Spring AOP / Caffeine) trade-off + validation criteria
- **`docs/cross-paradigm/mvc-vs-webflux.md`** (210 lines) — Phase 6 placeholder, 7 dimension 비교 axis 미리 정의

**Total**: 2,212 lines of narrative.

## Why This Structure

### 4-layer portfolio architecture (interviewer 가 보는 단계)

```
Layer 1 (5초)   README hero       — already in place
Layer 2 (2분)   TL;DR + 측정 표    — README + this PR
Layer 3 (15분)  STORY + 부록       — this PR's main
Layer 4 (면접)  INTERVIEW + ADR    — this PR's verification
```

각 layer 가 다 떨어지면 안 됨. 5초 흥미 못 끌면 2분 안 봄.

### NDA-aware framing throughout

- 회사명 / 외부 SaaS / 정확한 시각 / 매출 수치 / 내부 metric 이름 — 익명화
- 패턴 / timeline 구조 / 측정 방법론 / lessons — 보존
- 면접 NDA 질문 표준 답변 (`docs/INCIDENT.md` 마지막 섹션)

## Skeletons vs Filled Content

각 문서가 **skeleton + draft 혼합** 상태:

| 문서 | 현재 상태 | 채워질 시점 |
|---|---|---|
| STORY.md | Draft (anonymized real context) | Phase 진행하면서 검증 / 보완 |
| INCIDENT.md | Draft (Customer A 페르소나 + 익명 timeline) | Phase 1 코드 RCA 시 보완 |
| INTERVIEW.md | Draft (전체 답변 본인 입으로 가능한지 자가 점검) | Phase 5 polish 시 final |
| BENCHMARK.md | Methodology 완성 / 결과 placeholder | Phase 2 / 3 / 6 측정 후 채움 |
| DESIGN.md | Architecture 완성 (Mermaid) / 코드 라인 reference 는 Phase 1 후 정확 | Phase 1 코드 후 검증 |
| ADR-001 | Full Proposed (Phase 1 후 Accepted) | Phase 1 완료 시 status 갱신 |
| cross-paradigm/mvc-vs-webflux.md | Skeleton (7 dimension axis 정의) | Phase 6 측정 후 채움 |

## Test plan

문서 변경이라 자동 테스트 X. 수동 검증:

- [x] 모든 cross-link 유효성 (`docs/*.md` 끼리 + README 와)
- [x] Mermaid 다이어그램 GitHub 에서 렌더링 정상
- [x] NDA 검토 — 회사명 / 정확 수치 / 내부 메트릭 노출 0
- [ ] 본인 자가 읽기 — STORY.md 가 15분 안에 자연스럽게 읽히는지
- [ ] INTERVIEW.md 의 5분 답변을 본인 입으로 막힘없이 가능한지

## Follow-up

이 PR 머지 후:

1. **Phase 1 코드 시작** ([Issue #2](https://github.com/PreAgile/single-flight-coordinator-lab/issues/2)) — coordinator-core (Pure Java, no Spring)
2. Phase 1 끝나면 STORY/INCIDENT 의 incident detail 보완 (실 RCA 와 정합)
3. Phase 2 끝나면 BENCHMARK 의 Phase 2 결과 + Grafana 캡처
4. Phase 5 (polish) 에서 INTERVIEW 답변 final review

## Related

- Closes (none — narrative skeleton 자체는 Phase 의 일부 아님)
- Refs [#1 Epic](https://github.com/PreAgile/single-flight-coordinator-lab/issues/1)
- Discussion: portfolio narrative architecture (코딩 시작 전 narrative 깔기)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design and architecture documentation
  * Introduced standardized benchmarking methodology with performance measurement guidelines
  * Added incident analysis documentation with resolution details
  * Included architecture decision records and framework comparisons

<!-- end of auto-generated comment: release notes by coderabbit.ai -->