### PR TITLE
chore(build): introduce Spotless with lightweight Java hygiene rules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@
 
 plugins {
     java
+    id("com.diffplug.spotless") version "7.0.4"
 }
 
 allprojects {
@@ -15,6 +16,7 @@ allprojects {
 
 subprojects {
     apply(plugin = "java")
+    apply(plugin = "com.diffplug.spotless")
 
     extensions.configure<JavaPluginExtension> {
         toolchain {
@@ -33,5 +35,27 @@ subprojects {
     tasks.withType<JavaCompile>().configureEach {
         options.encoding = "UTF-8"
         options.compilerArgs.addAll(listOf("-Xlint:all", "-parameters"))
+    }
+
+    // Code style — lightweight Spotless rules.
+    //
+    // We deliberately do NOT use a heavy structural formatter (palantir-java-format
+    // / google-java-format). Both depend on internal javac APIs whose signatures
+    // change between JDK versions, producing fragile build failures
+    // (NoSuchMethodError on Log$DeferredDiagnosticHandler etc.) when contributors
+    // run on different JDKs. The codebase already uses consistent 4-space
+    // indentation enforced via IDE/.editorconfig conventions, and the rules below
+    // catch the cross-cutting hygiene drifts that commonly slip into PRs.
+    //
+    // Format on demand: ./gradlew spotlessApply
+    // CI gate: ./gradlew spotlessCheck (also runs as part of `check`)
+    extensions.configure<com.diffplug.gradle.spotless.SpotlessExtension> {
+        java {
+            target("src/**/*.java")
+            importOrder("java", "javax", "", "com.portfolio")
+            removeUnusedImports()
+            trimTrailingWhitespace()
+            endWithNewline()
+        }
     }
 }

--- a/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/adapter/InProcessSingleFlightCoordinator.java
+++ b/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/adapter/InProcessSingleFlightCoordinator.java
@@ -1,11 +1,5 @@
 package com.portfolio.singleflight.coordinator.adapter;
 
-import com.portfolio.singleflight.coordinator.InflightEntry;
-import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
-import com.portfolio.singleflight.coordinator.SingleFlightOptions;
-import com.portfolio.singleflight.coordinator.exception.CongestionException;
-import com.portfolio.singleflight.coordinator.exception.ForceReleasedException;
-
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -17,6 +11,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+
+import com.portfolio.singleflight.coordinator.InflightEntry;
+import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
+import com.portfolio.singleflight.coordinator.SingleFlightOptions;
+import com.portfolio.singleflight.coordinator.exception.CongestionException;
+import com.portfolio.singleflight.coordinator.exception.ForceReleasedException;
 
 /**
  * In-process Map-based coordinator (Issue #2 / Phase 1).

--- a/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/decorator/CapacityDecorator.java
+++ b/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/decorator/CapacityDecorator.java
@@ -1,13 +1,13 @@
 package com.portfolio.singleflight.coordinator.decorator;
 
-import com.portfolio.singleflight.coordinator.InflightEntry;
-import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
-import com.portfolio.singleflight.coordinator.SingleFlightOptions;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+
+import com.portfolio.singleflight.coordinator.InflightEntry;
+import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
+import com.portfolio.singleflight.coordinator.SingleFlightOptions;
 
 /**
  * Capacity decorator — applies a default {@code maxWaiters} cap to the

--- a/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/decorator/DeadlineDecorator.java
+++ b/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/decorator/DeadlineDecorator.java
@@ -1,16 +1,16 @@
 package com.portfolio.singleflight.coordinator.decorator;
 
-import com.portfolio.singleflight.coordinator.InflightEntry;
-import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
-import com.portfolio.singleflight.coordinator.SingleFlightOptions;
-import com.portfolio.singleflight.coordinator.exception.DeadlineExceededException;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
+
+import com.portfolio.singleflight.coordinator.InflightEntry;
+import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
+import com.portfolio.singleflight.coordinator.SingleFlightOptions;
+import com.portfolio.singleflight.coordinator.exception.DeadlineExceededException;
 
 /**
  * Deadline decorator — wraps the operation with a wall-clock timeout and

--- a/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/decorator/HeartbeatDecorator.java
+++ b/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/decorator/HeartbeatDecorator.java
@@ -1,12 +1,5 @@
 package com.portfolio.singleflight.coordinator.decorator;
 
-import com.portfolio.singleflight.coordinator.InflightEntry;
-import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
-import com.portfolio.singleflight.coordinator.SingleFlightOptions;
-import com.portfolio.singleflight.coordinator.observability.MetricSink;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +11,14 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.portfolio.singleflight.coordinator.InflightEntry;
+import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
+import com.portfolio.singleflight.coordinator.SingleFlightOptions;
+import com.portfolio.singleflight.coordinator.observability.MetricSink;
 
 /**
  * Heartbeat decorator — periodically scans inflight entries and warns about

--- a/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/decorator/TelemetryDecorator.java
+++ b/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/decorator/TelemetryDecorator.java
@@ -1,15 +1,5 @@
 package com.portfolio.singleflight.coordinator.decorator;
 
-import com.portfolio.singleflight.coordinator.InflightEntry;
-import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
-import com.portfolio.singleflight.coordinator.SingleFlightOptions;
-import com.portfolio.singleflight.coordinator.exception.CongestionException;
-import com.portfolio.singleflight.coordinator.exception.DeadlineExceededException;
-import com.portfolio.singleflight.coordinator.exception.ForceReleasedException;
-import com.portfolio.singleflight.coordinator.observability.MetricSink;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -17,6 +7,17 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.portfolio.singleflight.coordinator.InflightEntry;
+import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
+import com.portfolio.singleflight.coordinator.SingleFlightOptions;
+import com.portfolio.singleflight.coordinator.exception.CongestionException;
+import com.portfolio.singleflight.coordinator.exception.DeadlineExceededException;
+import com.portfolio.singleflight.coordinator.exception.ForceReleasedException;
+import com.portfolio.singleflight.coordinator.observability.MetricSink;
 
 /**
  * Telemetry decorator — outermost layer in the canonical stack.

--- a/coordinator-core/src/test/java/com/portfolio/singleflight/coordinator/adapter/InProcessSingleFlightCoordinatorTest.java
+++ b/coordinator-core/src/test/java/com/portfolio/singleflight/coordinator/adapter/InProcessSingleFlightCoordinatorTest.java
@@ -1,13 +1,8 @@
 package com.portfolio.singleflight.coordinator.adapter;
 
-import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
-import com.portfolio.singleflight.coordinator.SingleFlightOptions;
-import com.portfolio.singleflight.coordinator.exception.CongestionException;
-import com.portfolio.singleflight.coordinator.exception.ForceReleasedException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -20,9 +15,15 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.awaitility.Awaitility.await;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
+import com.portfolio.singleflight.coordinator.SingleFlightOptions;
+import com.portfolio.singleflight.coordinator.exception.CongestionException;
+import com.portfolio.singleflight.coordinator.exception.ForceReleasedException;
 
 /**
  * {@link InProcessSingleFlightCoordinator}의 행동 계약(behavioral contract).

--- a/coordinator-core/src/test/java/com/portfolio/singleflight/coordinator/decorator/CapacityDecoratorTest.java
+++ b/coordinator-core/src/test/java/com/portfolio/singleflight/coordinator/decorator/CapacityDecoratorTest.java
@@ -1,15 +1,8 @@
 package com.portfolio.singleflight.coordinator.decorator;
 
-import com.portfolio.singleflight.coordinator.InflightEntry;
-import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
-import com.portfolio.singleflight.coordinator.SingleFlightOptions;
-import com.portfolio.singleflight.coordinator.adapter.InProcessSingleFlightCoordinator;
-import com.portfolio.singleflight.coordinator.exception.CongestionException;
-import com.portfolio.singleflight.coordinator.exception.ForceReleasedException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -17,9 +10,17 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.awaitility.Awaitility.await;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.portfolio.singleflight.coordinator.InflightEntry;
+import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
+import com.portfolio.singleflight.coordinator.SingleFlightOptions;
+import com.portfolio.singleflight.coordinator.adapter.InProcessSingleFlightCoordinator;
+import com.portfolio.singleflight.coordinator.exception.CongestionException;
+import com.portfolio.singleflight.coordinator.exception.ForceReleasedException;
 
 /**
  * {@link CapacityDecorator}의 행동 계약(behavioral contract).

--- a/coordinator-core/src/test/java/com/portfolio/singleflight/coordinator/decorator/DeadlineDecoratorTest.java
+++ b/coordinator-core/src/test/java/com/portfolio/singleflight/coordinator/decorator/DeadlineDecoratorTest.java
@@ -1,18 +1,19 @@
 package com.portfolio.singleflight.coordinator.decorator;
 
-import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
-import com.portfolio.singleflight.coordinator.SingleFlightOptions;
-import com.portfolio.singleflight.coordinator.adapter.InProcessSingleFlightCoordinator;
-import com.portfolio.singleflight.coordinator.exception.DeadlineExceededException;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
+import com.portfolio.singleflight.coordinator.SingleFlightOptions;
+import com.portfolio.singleflight.coordinator.adapter.InProcessSingleFlightCoordinator;
+import com.portfolio.singleflight.coordinator.exception.DeadlineExceededException;
 
 class DeadlineDecoratorTest {
 

--- a/coordinator-core/src/test/java/com/portfolio/singleflight/coordinator/decorator/HeartbeatDecoratorTest.java
+++ b/coordinator-core/src/test/java/com/portfolio/singleflight/coordinator/decorator/HeartbeatDecoratorTest.java
@@ -1,12 +1,7 @@
 package com.portfolio.singleflight.coordinator.decorator;
 
-import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
-import com.portfolio.singleflight.coordinator.adapter.InProcessSingleFlightCoordinator;
-import com.portfolio.singleflight.coordinator.observability.MetricSink;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -14,10 +9,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.portfolio.singleflight.coordinator.adapter.InProcessSingleFlightCoordinator;
+import com.portfolio.singleflight.coordinator.observability.MetricSink;
 
 class HeartbeatDecoratorTest {
 

--- a/coordinator-core/src/test/java/com/portfolio/singleflight/coordinator/decorator/TelemetryDecoratorTest.java
+++ b/coordinator-core/src/test/java/com/portfolio/singleflight/coordinator/decorator/TelemetryDecoratorTest.java
@@ -1,13 +1,7 @@
 package com.portfolio.singleflight.coordinator.decorator;
 
-import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
-import com.portfolio.singleflight.coordinator.SingleFlightOptions;
-import com.portfolio.singleflight.coordinator.adapter.InProcessSingleFlightCoordinator;
-import com.portfolio.singleflight.coordinator.exception.CongestionException;
-import com.portfolio.singleflight.coordinator.exception.DeadlineExceededException;
-import com.portfolio.singleflight.coordinator.observability.MetricSink;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,8 +11,14 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
+import com.portfolio.singleflight.coordinator.adapter.InProcessSingleFlightCoordinator;
+import com.portfolio.singleflight.coordinator.exception.CongestionException;
+import com.portfolio.singleflight.coordinator.exception.DeadlineExceededException;
+import com.portfolio.singleflight.coordinator.observability.MetricSink;
 
 class TelemetryDecoratorTest {
 

--- a/coordinator-core/src/test/java/com/portfolio/singleflight/coordinator/integration/FullChainTest.java
+++ b/coordinator-core/src/test/java/com/portfolio/singleflight/coordinator/integration/FullChainTest.java
@@ -1,5 +1,21 @@
 package com.portfolio.singleflight.coordinator.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import com.portfolio.singleflight.coordinator.SingleFlightCoordinator;
 import com.portfolio.singleflight.coordinator.SingleFlightOptions;
 import com.portfolio.singleflight.coordinator.adapter.InProcessSingleFlightCoordinator;
@@ -10,21 +26,6 @@ import com.portfolio.singleflight.coordinator.decorator.TelemetryDecorator;
 import com.portfolio.singleflight.coordinator.exception.CongestionException;
 import com.portfolio.singleflight.coordinator.exception.DeadlineExceededException;
 import com.portfolio.singleflight.coordinator.observability.MetricSink;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.awaitility.Awaitility.await;
 
 /**
  * Integration tests for the full 5-layer decorator chain:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,22 @@
+# JVM arguments for the Gradle daemon.
+#
+# The --add-exports flags expose internal javac APIs to ALL-UNNAMED. Tools
+# that perform source-level static analysis or formatting (e.g. ErrorProne,
+# google-java-format, palantir-java-format) traverse these APIs and would
+# otherwise fail with InaccessibleObjectException / NoSuchMethodError
+# under JPMS-encapsulated JDKs.
+#
+# We currently use a lightweight Spotless config that does not require these,
+# but the flags are kept here so adding ErrorProne or a structural formatter
+# in a follow-up does not flake out on first run. They are no-ops for tools
+# that do not touch the javac internals.
+#
+# Reference: https://github.com/diffplug/spotless/blob/main/plugin-gradle/README.md#java
+org.gradle.jvmargs=-Xmx1g \
+    -XX:+IgnoreUnrecognizedVMOptions \
+    --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+    --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+    --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+    --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+    --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+    --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED


### PR DESCRIPTION
## Summary

- Add Spotless Gradle plugin (7.0.4) with a deliberately lightweight Java rule set.
- One-time mechanical reformat across 11 Java files — only import grouping and stray-whitespace cleanup, no source semantics changed.

## What's enforced

Per subproject (target `src/**/*.java`):
- `importOrder("java", "javax", "", "com.portfolio")` — stable grouping
- `removeUnusedImports`
- `trimTrailingWhitespace`
- `endWithNewline`

Auto-attaches to the standard `check` task, so PR drift will be caught by CI.

## What's deliberately NOT enforced

Heavy structural formatters (palantir-java-format, google-java-format) call into `com.sun.tools.javac.*` internals. JDK 21 → 25 changed several signatures (e.g. `Log$DeferredDiagnosticHandler.getDiagnostics` return type), so the formatter throws `NoSuchMethodError` on contributors whose Gradle daemon happens to boot on a newer JDK. The codebase already uses consistent 4-space indentation; the cost of catching rare structural drift is not worth this fragility. If we later want structural enforcement, we can pin the daemon JDK and revisit.

## Build / runtime additions

- `build.gradle.kts` — Spotless plugin + per-subproject rule config.
- `gradle.properties` — `org.gradle.jvmargs` adds `--add-exports` for `jdk.compiler.*`. Currently no-op for our lightweight ruleset, but kept for forward compatibility with ErrorProne / NullAway in subsequent PRs.

## Developer workflow

```bash
./gradlew spotlessApply   # auto-fix in place
./gradlew spotlessCheck   # CI gate (also runs as part of `check`)
```

## Test plan

- [x] `./gradlew check` green (Spotless + 35 coordinator-core tests)
- [x] `./gradlew spotlessApply` is idempotent
- [x] Mechanical reformat confirmed to be import-only via `git diff --stat`

## PR series

This is **PR #1 of a 4-PR follow-up series** captured in CLAUDE.md's testing-conventions discussion:

1. **chore: Spotless** ← this PR
2. chore: ErrorProne (compile-time static checks)
3. docs: CONTRIBUTING.md
4. chore: JSpecify (nullability annotations)

Each PR is independently revertable per the Conventional Commits convention pinned in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)