### PR TITLE
chore(build): introduce ErrorProne with fixes for the 3 issues it found

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,10 @@
 // Root build script — common config for all subprojects.
 
+import net.ltgt.gradle.errorprone.errorprone
+
 plugins {
     java
+    id("net.ltgt.errorprone") version "4.1.0"
 }
 
 allprojects {
@@ -15,11 +18,16 @@ allprojects {
 
 subprojects {
     apply(plugin = "java")
+    apply(plugin = "net.ltgt.errorprone")
 
     extensions.configure<JavaPluginExtension> {
         toolchain {
             languageVersion.set(JavaLanguageVersion.of(21))
         }
+    }
+
+    dependencies {
+        "errorprone"("com.google.errorprone:error_prone_core:2.39.0")
     }
 
     tasks.withType<Test>().configureEach {
@@ -33,5 +41,17 @@ subprojects {
     tasks.withType<JavaCompile>().configureEach {
         options.encoding = "UTF-8"
         options.compilerArgs.addAll(listOf("-Xlint:all", "-parameters"))
+
+        // ErrorProne — compile-time static analysis (Google).
+        // Catches common Java traps (equals/hashCode mismatch, format string
+        // errors, Future ignored, etc.) before code review even sees them.
+        //
+        // Disabled on test sources: tests legitimately use patterns that
+        // ErrorProne flags (deliberate equality checks, intentional throws),
+        // and contract tests are already a strong signal of behavior.
+        options.errorprone.disableWarningsInGeneratedCode.set(true)
+        if (name.contains("Test", ignoreCase = true)) {
+            options.errorprone.isEnabled.set(false)
+        }
     }
 }

--- a/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/adapter/InProcessSingleFlightCoordinator.java
+++ b/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/adapter/InProcessSingleFlightCoordinator.java
@@ -107,7 +107,7 @@ public final class InProcessSingleFlightCoordinator implements SingleFlightCoord
             }
 
             InflightRecord<T> record = new InflightRecord<>(
-                    key, future, System.currentTimeMillis(), new AtomicInteger(1));
+                    future, System.currentTimeMillis(), new AtomicInteger(1));
             // Caller gets an independent copy (cancel isolation); the map and
             // the cleanup hook keep the original for identity-based eviction.
             resultRef.set(future.copy());
@@ -124,7 +124,11 @@ public final class InProcessSingleFlightCoordinator implements SingleFlightCoord
         // is visible when the hook runs.
         CompletableFuture<T> newOwner = newOwnerRef.get();
         if (newOwner != null) {
-            newOwner.whenComplete((v, e) -> evictIfStillOwner(key, newOwner));
+            // The returned stage from whenComplete is intentionally discarded —
+            // the registration itself is the side effect we want, and there's
+            // no further chain to attach. `var unused` makes that intent
+            // explicit for ErrorProne's FutureReturnValueIgnored check.
+            var unused = newOwner.whenComplete((v, e) -> evictIfStillOwner(key, newOwner));
         }
 
         CompletableFuture<T> result = resultRef.get();
@@ -178,13 +182,11 @@ public final class InProcessSingleFlightCoordinator implements SingleFlightCoord
      * {@link #getInflightState()}).
      */
     private static final class InflightRecord<T> {
-        final String key;
         final CompletableFuture<T> future;
         final long startedAt;
         final AtomicInteger waiterCount;
 
-        InflightRecord(String key, CompletableFuture<T> future, long startedAt, AtomicInteger waiterCount) {
-            this.key = key;
+        InflightRecord(CompletableFuture<T> future, long startedAt, AtomicInteger waiterCount) {
             this.future = future;
             this.startedAt = startedAt;
             this.waiterCount = waiterCount;

--- a/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/decorator/TelemetryDecorator.java
+++ b/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/decorator/TelemetryDecorator.java
@@ -81,7 +81,7 @@ public final class TelemetryDecorator implements SingleFlightCoordinator {
         String status = classifyStatus(error);
         Map<String, String> tags = Map.of("status", status, "tag", tag);
 
-        metrics.recordHistogram("singleflight.owner_duration_ms", durationMs, tags);
+        metrics.recordHistogram("singleflight.owner_duration_ms", (double) durationMs, tags);
 
         if (error == null) {
             log.info(


### PR DESCRIPTION
## Summary

Add Google's ErrorProne to the compileJava pipeline. Catches 3 real issues on first run; all fixed in the same commit so the tree stays clean.

## What ErrorProne caught

| File | Check | Fix |
|------|-------|-----|
| `TelemetryDecorator.java:84` | `LongDoubleConversion` | Explicit `(double)` cast on `durationMs` |
| `InProcessSingleFlightCoordinator.java:181` | `UnusedVariable` | Removed dead `final String key` field from `InflightRecord` |
| `InProcessSingleFlightCoordinator.java:127` | `FutureReturnValueIgnored` | `var unused = newOwner.whenComplete(...)` to mark intentional discard |

None of these were behavior bugs — `LongDoubleConversion` is precision-correctness in extreme cases (past 2^53 ms ≈ 285 millennia), `UnusedVariable` is dead code, and `FutureReturnValueIgnored` is a deliberate pattern. Including the fixes in the same PR keeps "introduce ErrorProne" self-contained.

## Configuration

Per subproject (target main sources only):
- Plugin `net.ltgt.errorprone` 4.1.0
- `error_prone_core` 2.39.0 (JDK 25 compatible)
- `disableWarningsInGeneratedCode = true`
- ErrorProne disabled on test sources (test patterns legitimately trip its noisier checks)

## Test plan

- [x] `./gradlew check` green — compile (ErrorProne clean), Spotless clean, 35 coordinator-core tests passing
- [x] ErrorProne is disabled on `compileTestJava` (verified by inspecting build output)
- [x] Issues #1-#3 from the first compileJava run are all eliminated; subsequent compiles are warning-free

## Stacking

Branched from `feat/phase-1-coordinator-core` and targeted at it. After PR #9 merges, this PR's base auto-flips to `main`. PR #1 (Spotless) and this PR (#2 ErrorProne) are independent — either can merge first.

## PR series

PR **#2 of 4** in the follow-up series:

1. chore: Spotless (PR #10)
2. **chore: ErrorProne** ← this PR
3. docs: CONTRIBUTING.md
4. chore: JSpecify (nullability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)