### PR TITLE
chore(coordinator-core): introduce JSpecify nullability annotations (gradual rollout)

### DIFF
--- a/coordinator-core/build.gradle.kts
+++ b/coordinator-core/build.gradle.kts
@@ -7,6 +7,12 @@
 // (Prometheus, Datadog 등) 는 consumer 가 결정.
 
 dependencies {
+    // Nullability annotations — JSpecify is the modern Java standard
+    // (replaces JSR-305 / FindBugs / Checker / JetBrains variants).
+    // Annotations are RetentionPolicy.CLASS so they live in bytecode for
+    // tooling (NullAway, IDE) without runtime overhead.
+    implementation("org.jspecify:jspecify:1.0.0")
+
     // 메트릭 인터페이스 — Spring 무관, 표준 라이브러리
     implementation("io.micrometer:micrometer-core:1.12.0")
 

--- a/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/SingleFlightCoordinator.java
+++ b/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/SingleFlightCoordinator.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Per-key, once-at-a-time async execution with coalesced results.
  *
@@ -71,8 +73,10 @@ public interface SingleFlightCoordinator {
      * cancellation discussion).
      *
      * @param key    coalescing key to release
-     * @param reason human-readable reason for telemetry / logs
+     * @param reason human-readable reason for telemetry / logs; may be
+     *               {@code null} when no contextual reason is available
+     *               (e.g. shutdown sweepers)
      * @return future that completes when the release signal has been recorded
      */
-    CompletableFuture<Void> forceRelease(String key, String reason);
+    CompletableFuture<Void> forceRelease(String key, @Nullable String reason);
 }

--- a/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/package-info.java
+++ b/coordinator-core/src/main/java/com/portfolio/singleflight/coordinator/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * SingleFlight 코디네이터 핵심 추상화 — 동일 키에 대한 동시 호출자를 한 번의
+ * 작업 수행으로 합치는 패턴(coalescing)의 Java 인터페이스 / DTO 묶음.
+ *
+ * <p>이 패키지의 모든 타입은 JSpecify {@link org.jspecify.annotations.NullMarked}
+ * 로 선언되어, 별도 표시가 없는 모든 타입 사용은 <b>non-null</b>로 간주된다.
+ * null이 합법적인 자리에는 명시적으로 {@link org.jspecify.annotations.Nullable}
+ * 을 단다.
+ *
+ * <p>JSpecify는 컴파일 타임 nullability 명세이며, 런타임 검사가 아니다. 실제
+ * NPE 차단은 public API 진입점의 {@code Objects.requireNonNull} 가드가 담당한다
+ * (관련 contract 테스트는 {@link com.portfolio.singleflight.coordinator.adapter
+ * .InProcessSingleFlightCoordinator} 의 [7] 입력 계약 그룹 참조).
+ */
+@NullMarked
+package com.portfolio.singleflight.coordinator;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## Summary

Adopt JSpecify (1.0.0) as the project's nullability annotation standard. Establish the convention on the public-facing top-level package first; sub-packages adopt later as their contracts get audited.

## Why JSpecify

The modern Java consensus — replaces the older fragmented choices:

| Old | New |
|-----|-----|
| `javax.annotation.Nullable` (JSR-305) | `org.jspecify.annotations.Nullable` |
| `org.checkerframework.checker.nullness.qual.Nullable` | (same) |
| `org.jetbrains.annotations.Nullable` | (same) |
| Multiple `@Nonnull` / `@NotNull` / `@NonNull` variants | `@NullMarked` at package level |

Annotations have `RetentionPolicy.CLASS` so they live in bytecode for tooling pickup (NullAway, IDE inspections) without runtime overhead.

## Scope — deliberately minimal

| Package | This PR |
|---------|---------|
| `com.portfolio.singleflight.coordinator` | ✅ `@NullMarked` via `package-info.java` |
| `...coordinator.adapter` | ⏳ follow-up |
| `...coordinator.decorator` | ⏳ follow-up |
| `...coordinator.exception` | ⏳ follow-up |
| `...coordinator.observability` | ⏳ follow-up |

Each sub-package merits its own nullability audit; bundling them all here would muddy review.

## Concrete changes

- `coordinator-core/build.gradle.kts` — `implementation("org.jspecify:jspecify:1.0.0")`
- `package-info.java` (new) — `@NullMarked` on `com.portfolio.singleflight.coordinator`
- `SingleFlightCoordinator.java` — `forceRelease(String key, @Nullable String reason)` documents the de-facto contract (impl already accepts null reason; no `requireNonNull` on it)

## What's NOT in this PR

- Sub-package `@NullMarked` rollouts
- NullAway / ErrorProne integration for JSpecify enforcement
- Per-method `@Nullable` annotations on individual implementation files

These are scoped out by design — each is independently revertable.

## Test plan

- [x] `./gradlew check` green — 35 coordinator-core tests pass
- [x] ErrorProne stays clean (JSpecify annotations not flagged)
- [x] Spotless stays clean (no formatting drift)
- [x] No runtime overhead: annotations are class-retention only

## PR series — final

PR **#4 of 4** in the follow-up series:

1. chore: Spotless (PR #10)
2. chore: ErrorProne (PR #11)
3. docs: CONTRIBUTING.md (PR #12)
4. **chore: JSpecify** ← this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)